### PR TITLE
cannon/change-2b45ad29

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -20,7 +20,7 @@ jobs:
     if: (github.event_name == 'push') ||  (startsWith( github.head_ref, 'branch/' ))
     steps:
       - uses: actions/checkout@v2
-      - uses: canonical/charmhub-upload-action@v0.2.0
+      - uses: canonical/charmhub-upload-action@0.2.0
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           charm-path: ./


### PR DESCRIPTION
Changes applied by commit-cannon:
  * Ran command `find . -name metadata.yaml -exec yq -i eval 'del(.display-name)' {} \;`
  * Ran command `find . -name metadata.yaml -exec yq -i eval 'del(.maintainers)' {} \;`
  * Ran command `find . -name metadata.yaml -exec yq -i eval 'del(.tags)' {} \;`
  * Ran command `find . -name metadata.yaml -exec yq -i eval 'del(.auto-fetch)' {} \;`
  * Ran command `find . -name metadata.yaml -exec yq -i eval 'del(.min-juju-version)' {} \;`
  * Ran command `find . -name metadata.yaml -exec yq -i eval 'del(.deployment)' {} \;`
  * Ran command `find . -name metadata.yaml -exec yq -i eval 'del(.requires.type)' {} \;`
  * Ran command `find . -name metadata.yaml -exec yq -i eval 'del(.requires.service)' {} \;`
  * Ran command `find . -name metadata.yaml -exec yq -i eval 'del(.resources.type)' {} \;`
  * Ran command `find . -name metadata.yaml -exec yq -i eval 'del(.resources.service)' {} \;`
  * Replaced file `.github/workflows/publish.yaml`
