### PR TITLE
update readme with marketing copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,79 @@
-Seldon Core Operator
-====================
+## Seldon Core Operator - a component of the Charmed Kubeflow distribution from Canonical
+## Looking for a fully supported platform for MLOps?
 
-### Overview
+Canonical [Charmed Kubeflow](https://charmed-kubeflow.io) is a state of the art, fully supported MLOps platform that helps data scientists collaborate on AI innovation on any cloud from concept to production, offered by Canonical - the publishers of [Ubuntu](https://ubuntu.com).
+
+<br/>
+
+[![Kubeflow diagram](https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_350,h_304/https://assets.ubuntu.com/v1/10400c98-Charmed-kubeflow-Topology-header.svg)](https://charmed-kubeflow.io)
+
+<br/>
+
+Charmed Kubeflow is free to use: the solution can be deployed in any environment without constraints, paywall or restricted features. Data labs and MLOps teams only need to train their data scientists and engineers once to work consistently and efficiently on any cloud – or on-premise.
+
+Charmed Kubeflow offers a centralised, browser-based MLOps platform that runs on any conformant Kubernetes – offering enhanced productivity, improved governance and reducing the risks associated with shadow IT.
+
+Learn more about deploying and using Charmed Kubeflow at [https://charmed-kubeflow.io](https://charmed-kubeflow.io).
+
+<br/>
+
+### Key features
+* Centralised, browser-based data science workspaces: **familiar experience**
+* Multi user: **one environment for your whole data science team**
+* NVIDIA GPU support: **accelerate deep learning model training**
+* Apache Spark integration: **empower big data driven model training**
+* Ideation to production: **automate model training & deployment**
+* AutoML: **Hyperparameter tuning, architecture search**
+* Composable: **edge deployment configurations available**
+
+<br/>
+
+### What’s included in Charmed Kubeflow 1.3
+* LDAP Authentication
+* Jupyter Notebooks
+* Work with Python and R
+* TensorFlow, Pytorch, MXNet, XGBoost
+* TFServing, Seldon-Core
+* Katib (autoML)
+* Apache Spark
+* Argo Workflows
+* Kubeflow Pipelines
+
+<br/>
+
+### Why engineers and data scientists choose Charmed Kubeflow
+* Maintenance: Charmed Kubeflow offers up to two years of maintenance on select releases
+* Optional 24/7 support available, [contact us here](https://charmed-kubeflow.io/contact-us) for more information
+* Optional dedicated fully managed service available, [contact us here](https://charmed-kubeflow.io/contact-us) for more information or [learn more about Canonical’s Managed Apps service](https://ubuntu.com/managed/apps).
+* Portability: Charmed Kubeflow can be deployed on any conformant Kubernetes, on any cloud or on-premise
+
+<br/>
+
 This repository hosts the Kubernetes Python Operator for Seldon Core
 (see [CharmHub](https://charmhub.io/?q=seldon-core)).
 
-The Seldon Core Operator is a Python script that wraps the latest released Seldon Core manifest,
-providing lifecycle management and handling events (install, upgrade, integrate, remove).
+The Seldon Core Operator is a Python script that wraps the latest released Seldon Core manifest, providing lifecycle management and handling events (install, upgrade, integrate, remove).
+
+<br/>
+
+### Documentation
+Please see the [official docs site](https://charmed-kubeflow.io/docs) for complete documentation of the Charmed Kubeflow distribution.
+
+### Bugs and feature requests
+If you find a bug in our operator or want to request a specific feature, please file a bug here: 
+[https://github.com/canonical/seldon-core-operator/issues](https://github.com/canonical/seldon-core-operator/issues)
+
+<br/>
+
+### License
+Charmed Kubeflow is free software, distributed under the [Apache Software License, version 2](https://github.com/canonical/seldon-core-operator/blob/master/LICENSE).
+
+<br/>
+
+### Contributing
+Canonical welcomes contributions to Charmed Kubeflow. Please check out our contributing guide if you're interested in contributing to the distribution.
+
+<br/>
+
+### Security
+Security issues in Charmed Kubeflow can be reported by sending an email to [security@canonical.com](mailto:security@canonical.com). Please do not file GitHub issues about security issues.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The Seldon Core Operator is a Python script that wraps the latest released Seldo
 ### Usage
 
 The Seldon Core Operator may be deployed using the Juju command line as
-in
+follows
 
 ```sh
 $ juju deploy seldon-core
@@ -18,11 +18,8 @@ $ juju deploy seldon-core
 
 Canonical [Charmed Kubeflow](https://charmed-kubeflow.io) is a state of the art, fully supported MLOps platform that helps data scientists collaborate on AI innovation on any cloud from concept to production, offered by Canonical - the publishers of [Ubuntu](https://ubuntu.com).
 
-<br/>
-
 [![Kubeflow diagram](https://res.cloudinary.com/canonical/image/fetch/f_auto,q_auto,fl_sanitize,w_350,h_304/https://assets.ubuntu.com/v1/10400c98-Charmed-kubeflow-Topology-header.svg)](https://charmed-kubeflow.io)
 
-<br/>
 
 Charmed Kubeflow is free to use: the solution can be deployed in any environment without constraints, paywall or restricted features. Data labs and MLOps teams only need to train their data scientists and engineers once to work consistently and efficiently on any cloud – or on-premise.
 
@@ -30,7 +27,6 @@ Charmed Kubeflow offers a centralised, browser-based MLOps platform that runs on
 
 Learn more about deploying and using Charmed Kubeflow at [https://charmed-kubeflow.io](https://charmed-kubeflow.io).
 
-<br/>
 
 ### Key features
 * Centralised, browser-based data science workspaces: **familiar experience**
@@ -41,28 +37,23 @@ Learn more about deploying and using Charmed Kubeflow at [https://charmed-kubefl
 * AutoML: **hyperparameter tuning, architecture search**
 * Composable: **edge deployment configurations available**
 
-<br/>
 
 ### What’s included in Charmed Kubeflow 1.4
 * LDAP Authentication
 * Jupyter Notebooks
 * Work with Python and R
-* TensorFlow, Pytorch, MXNet, XGBoost
+* Support for TensorFlow, Pytorch, MXNet, XGBoost
 * TFServing, Seldon-Core
 * Katib (autoML)
 * Apache Spark
 * Argo Workflows
 * Kubeflow Pipelines
 
-<br/>
-
 ### Why engineers and data scientists choose Charmed Kubeflow
 * Maintenance: Charmed Kubeflow offers up to two years of maintenance on select releases
 * Optional 24/7 support available, [contact us here](https://charmed-kubeflow.io/contact-us) for more information
 * Optional dedicated fully managed service available, [contact us here](https://charmed-kubeflow.io/contact-us) for more information or [learn more about Canonical’s Managed Apps service](https://ubuntu.com/managed/apps).
 * Portability: Charmed Kubeflow can be deployed on any conformant Kubernetes, on any cloud or on-premise
-
-<br/>
 
 ### Documentation
 Please see the [official docs site](https://charmed-kubeflow.io/docs) for complete documentation of the Charmed Kubeflow distribution.
@@ -71,16 +62,13 @@ Please see the [official docs site](https://charmed-kubeflow.io/docs) for comple
 If you find a bug in our operator or want to request a specific feature, please file a bug here: 
 [https://github.com/canonical/seldon-core-operator/issues](https://github.com/canonical/seldon-core-operator/issues)
 
-<br/>
 
 ### License
 Charmed Kubeflow is free software, distributed under the [Apache Software License, version 2.0](https://github.com/canonical/seldon-core-operator/blob/master/LICENSE).
 
-<br/>
 
 ### Contributing
 Canonical welcomes contributions to Charmed Kubeflow. Please check out our [contributor agreement](https://ubuntu.com/legal/contributors) if you're interested in contributing to the distribution.
-<br/>
 
 ### Security
-Security issues in Charmed Kubeflow can be reported by sending an email to [security@canonical.com](mailto:security@canonical.com). Please do not file GitHub issues about security issues.
+Security issues in Charmed Kubeflow can be reported through [LaunchPad](https://wiki.ubuntu.com/DebuggingSecurity#How%20to%20File). Please do not file GitHub issues about security issues.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
 ## Seldon Core Operator - a component of the Charmed Kubeflow distribution from Canonical
+
+This repository hosts the Kubernetes Python Operator for Seldon Core
+(see [CharmHub](https://charmhub.io/?q=seldon-core)).
+
+The Seldon Core Operator is a Python script that wraps the latest released Seldon Core manifest, providing lifecycle management and handling events (install, upgrade, integrate, remove).
+
+### Usage
+
+The Seldon Core Operator may be deployed using the Juju command line as
+in
+
+```sh
+$ juju deploy seldon-core
+```
+
 ## Looking for a fully supported platform for MLOps?
 
 Canonical [Charmed Kubeflow](https://charmed-kubeflow.io) is a state of the art, fully supported MLOps platform that helps data scientists collaborate on AI innovation on any cloud from concept to production, offered by Canonical - the publishers of [Ubuntu](https://ubuntu.com).
@@ -23,12 +38,12 @@ Learn more about deploying and using Charmed Kubeflow at [https://charmed-kubefl
 * NVIDIA GPU support: **accelerate deep learning model training**
 * Apache Spark integration: **empower big data driven model training**
 * Ideation to production: **automate model training & deployment**
-* AutoML: **Hyperparameter tuning, architecture search**
+* AutoML: **hyperparameter tuning, architecture search**
 * Composable: **edge deployment configurations available**
 
 <br/>
 
-### What’s included in Charmed Kubeflow 1.3
+### What’s included in Charmed Kubeflow 1.4
 * LDAP Authentication
 * Jupyter Notebooks
 * Work with Python and R
@@ -49,13 +64,6 @@ Learn more about deploying and using Charmed Kubeflow at [https://charmed-kubefl
 
 <br/>
 
-This repository hosts the Kubernetes Python Operator for Seldon Core
-(see [CharmHub](https://charmhub.io/?q=seldon-core)).
-
-The Seldon Core Operator is a Python script that wraps the latest released Seldon Core manifest, providing lifecycle management and handling events (install, upgrade, integrate, remove).
-
-<br/>
-
 ### Documentation
 Please see the [official docs site](https://charmed-kubeflow.io/docs) for complete documentation of the Charmed Kubeflow distribution.
 
@@ -66,13 +74,12 @@ If you find a bug in our operator or want to request a specific feature, please 
 <br/>
 
 ### License
-Charmed Kubeflow is free software, distributed under the [Apache Software License, version 2](https://github.com/canonical/seldon-core-operator/blob/master/LICENSE).
+Charmed Kubeflow is free software, distributed under the [Apache Software License, version 2.0](https://github.com/canonical/seldon-core-operator/blob/master/LICENSE).
 
 <br/>
 
 ### Contributing
-Canonical welcomes contributions to Charmed Kubeflow. Please check out our contributing guide if you're interested in contributing to the distribution.
-
+Canonical welcomes contributions to Charmed Kubeflow. Please check out our [contributor agreement](https://ubuntu.com/legal/contributors) if you're interested in contributing to the distribution.
 <br/>
 
 ### Security

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Seldon Core Operator may be deployed using the Juju command line as
 follows
 
 ```sh
-$ juju deploy seldon-core
+$ juju deploy seldon-core seldon-controller-manager
 ```
 
 ## Looking for a fully supported platform for MLOps?


### PR DESCRIPTION
Updating the readme to create a cohesive branding for kubeflow charms

I moved the existing text to the $charm-instruction$ section. Let me know if you have any ideas on improving that section. 
The instruction section is also buried in the middle of the text. I think it's better to have a separate header for it.

The copy provided by Rob: https://docs.google.com/document/d/11FeczUu9Rk8PsgAayF6LIwUHA6RVKGwGY5bhxi5S6b4/edit