### PR TITLE
suggested edits for the webhook label fixes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,10 @@
 name: CI
 
 on:
-  - push
-  - pull_request
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,8 +49,6 @@ jobs:
 
     - name: Run integration tests
       run: tox -vve integration -- --model testing
-      env:
-        KUBECONFIG: /home/runner/.kube/config
 
     # On failure, capture debugging resources
     - name: Get all

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,8 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - master
-  pull_request:
+  - push
+  - pull_request
 
 jobs:
   lint:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -41,6 +41,7 @@ async def test_seldon_deployment(ops_test: OpsTest):
 
     this_ns = client.get(res=Namespace, name=namespace)
     this_ns.metadata.labels.update({"serving.kubeflow.org/inferenceservice": "enabled"})
+    client.patch(res=Namespace, name=this_ns.metadata.name, obj=this_ns)
 
     SeldonDeployment = create_namespaced_resource(
         group="machinelearning.seldon.io",

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,4 @@ commands =
 deps =
     {[testenv]deps}
     pytest-operator
-passenv =
-  KUBECONFIG
 commands = pytest -v --tb native --log-cli-level=INFO -s {posargs} {toxinidir}/tests/integration


### PR DESCRIPTION
* replaces kubectl call with lightkube
* splits tests into separate build_and_deploy and seldon_deployment (eg: job) tests for easier debugging of tests (this way if debugging the sample seldon job, the tests can run with `-k test_seldon_deployment` and wont rebuild/deploy the charm every time)
* runs everything in the test's juju model/namespace