### PR TITLE
fix: istio integration and add an example

### DIFF
--- a/.jujuignore
+++ b/.jujuignore
@@ -1,0 +1,5 @@
+/venv
+*.py[cod]
+*.charm
+.tox
+__pycache__

--- a/README.md
+++ b/README.md
@@ -14,6 +14,15 @@ follows
 $ juju deploy seldon-core seldon-controller-manager
 ```
 
+Seldon also offers significant but optional integration with Istio, using gateways,
+ virtual services, etc., to provide an improved model serving experience.  To integrate
+ with an existing implementation of Istio, simply provide the Istio gateway name as
+ configuration:
+
+```sh
+juju config seldon-controller-manager istio-gateway=my-gateway-name
+```
+
 ## Looking for a fully supported platform for MLOps?
 
 Canonical [Charmed Kubeflow](https://charmed-kubeflow.io) is a state of the art, fully supported MLOps platform that helps data scientists collaborate on AI innovation on any cloud from concept to production, offered by Canonical - the publishers of [Ubuntu](https://ubuntu.com).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository hosts the Kubernetes Python Operator for Seldon Core
 
 The Seldon Core Operator is a Python script that wraps the latest released Seldon Core manifest, providing lifecycle management and handling events (install, upgrade, integrate, remove).
 
-### Usage
+### Deployment
 
 The Seldon Core Operator may be deployed using the Juju command line as
 follows
@@ -22,6 +22,11 @@ Seldon also offers significant but optional integration with Istio, using gatewa
 ```sh
 juju config seldon-controller-manager istio-gateway=my-gateway-name
 ```
+
+### Usage examples
+
+See [this example](examples/ingress_canary_and_auth.ipynb) to deploy and use 
+ `SeldonDeployment` both with and without a protected Ingress Gateway.
 
 ## Looking for a fully supported platform for MLOps?
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,14 @@
+# Copyright 2021 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+type: charm
+bases:
+  - build-on:
+      - name: "ubuntu"
+        channel: "20.04"
+    run-on:
+      - name: "ubuntu"
+        channel: "20.04"
+parts:
+  charm:
+    charm-python-packages: [setuptools, pip]  # Fixes install of some packages

--- a/examples/ingress_canary_and_auth.ipynb
+++ b/examples/ingress_canary_and_auth.ipynb
@@ -2,6 +2,17 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "c4622ff6-be0d-4e8a-95c7-24c3140b488f",
+   "metadata": {},
+   "source": [
+    "# NOTE:\n",
+    "\n",
+    "\n",
+    "This guide requires the seldon-core charm revision >55 and istio-pilot charm revision >62.  As these are rolled out, you may need to deploy from the edge channel (`--channel latest/edge`) or build locally (`charmcraft pack`) for those charms.  See [seldon-core](https://charmhub.io/seldon-core) and [istio-pilot](https://charmhub.io/istio-pilot) in Charmhub to check the available versions."
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5bb813f8-7ac3-4b29-8a28-565da47baac6",
    "metadata": {},
    "source": [
@@ -53,7 +64,7 @@
    "outputs": [],
    "source": [
     "gateway_name = \"seldon-gateway\"\n",
-    "model_name = \"seldon-model\""
+    "juju_model_name = \"seldon-model\""
    ]
   },
   {
@@ -63,13 +74,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!juju add-model $model_name\n",
+    "!juju add-model $juju_model_name\n",
     "\n",
-    "!juju deploy istio-gateway istio-ingressgateway --trust --kind=ingress\n",
-    "!juju deploy istio-pilot --trust --config default-gateway=$model_name/$gateway_name\n",
+    "!juju deploy istio-gateway istio-ingressgateway --trust --channel 1.5/stable\n",
+    "!juju deploy istio-pilot --trust --config default-gateway=$gateway_name --channel 1.5/stable\n",
+    "# !juju deploy istio-gateway istio-ingressgateway --trust --kind=ingress\n",
+    "# !juju deploy istio-pilot --trust --config default-gateway=$gateway_name\n",
+    "\n",
     "!juju relate istio-pilot:istio-pilot istio-ingressgateway:istio-pilot\n",
     "\n",
-    "!juju deploy seldon-core --config istio-gateway=$model_name/$gateway_name"
+    "# Note: $juju_model_name here in the istio-gateway is the namespace that the GATEWAY \n",
+    "# is deployed to, which in our example happens to be the same as the seldon deployment\n",
+    "# but in practice could be different.\n",
+    "!juju deploy seldon-core seldon-controller-manager --config istio-gateway=$juju_model_name/$gateway_name"
    ]
   },
   {
@@ -125,7 +142,7 @@
     }
    ],
    "source": [
-    "gateway_ip=!kubectl get svc istio-ingressgateway -o yaml -o jsonpath='{.status.loadBalancer.ingress[0].ip}'\n",
+    "gateway_ip=!kubectl -n $juju_model_name get svc istio-ingressgateway -o yaml -o jsonpath='{.status.loadBalancer.ingress[0].ip}'\n",
     "gateway_ip = gateway_ip[0]\n",
     "print(f\"Our Istio ingressgateway ip: {gateway_ip}\")"
    ]
@@ -247,7 +264,7 @@
    "outputs": [],
    "source": [
     "jsonpath=\"'{.items[0].metadata.name}'\"\n",
-    "deployment_name = !kubectl get deploy -l seldon-deployment-id=$seldon_deployment_name -o jsonpath=$jsonpath\n",
+    "deployment_name = !kubectl -n $juju_model_name get deploy -l seldon-deployment-id=$seldon_deployment_name -o jsonpath=$jsonpath\n",
     "deployment_name = deployment_name[0]"
    ]
   },
@@ -267,7 +284,7 @@
     }
    ],
    "source": [
-    "!kubectl rollout status deploy/$deployment_name"
+    "!kubectl -n $juju_model_name rollout status deploy/$deployment_name"
    ]
   },
   {
@@ -306,7 +323,7 @@
     "sc = SeldonClient(\n",
     "    gateway=\"istio\",\n",
     "    deployment_name=seldon_deployment_name,\n",
-    "    namespace=model_name,\n",
+    "    namespace=juju_model_name,\n",
     "    gateway_endpoint=gateway_ip\n",
     ")\n"
    ]
@@ -383,7 +400,7 @@
    ],
    "source": [
     "jsonpath = \"'{.items[0].spec.clusterIP}'\"\n",
-    "classifier_svc_ip=!kubectl get svc -l seldon-deployment-id=$seldon_deployment_name,seldon.io/model=true -o jsonpath=$jsonpath\n",
+    "classifier_svc_ip=!kubectl -n $juju_model_name get svc -l seldon-deployment-id=$seldon_deployment_name,seldon.io/model=true -o jsonpath=$jsonpath\n",
     "classifier_svc_ip = classifier_svc_ip[0]\n",
     "content_type = \"'Content-Type: application/json'\"\n",
     "data = '\\'{\"data\": { \"ndarray\": [[1]]}}\\''\n",
@@ -414,7 +431,7 @@
     }
    ],
    "source": [
-    "!curl $gateway_ip/seldon/$model_name/$seldon_deployment_name/api/v1.0/predictions -X POST -H $content_type -d $data"
+    "!curl $gateway_ip/seldon/$juju_model_name/$seldon_deployment_name/api/v1.0/predictions -X POST -H $content_type -d $data"
    ]
   },
   {
@@ -533,7 +550,7 @@
     }
    ],
    "source": [
-    "!kubectl create -f canary.yaml"
+    "!kubectl -n $juju_model_name create -f canary.yaml"
    ]
   },
   {
@@ -544,7 +561,7 @@
    "outputs": [],
    "source": [
     "jsonpath=\"'{.items[0].metadata.name}'\"\n",
-    "deployment_name = !kubectl get deploy -l seldon-deployment-id=$seldon_deployment_canary_name -o jsonpath=$jsonpath\n",
+    "deployment_name = !kubectl -n $juju_model_name get deploy -l seldon-deployment-id=$seldon_deployment_canary_name -o jsonpath=$jsonpath\n",
     "deployment_name = deployment_name[0]"
    ]
   },
@@ -564,7 +581,7 @@
     }
    ],
    "source": [
-    "!kubectl rollout status deploy/$deployment_name"
+    "!kubectl -n $juju_model_name rollout status deploy/$deployment_name"
    ]
   },
   {
@@ -611,7 +628,7 @@
     "sc = SeldonClient(\n",
     "    gateway=\"istio\",\n",
     "    deployment_name=seldon_deployment_canary_name,\n",
-    "    namespace=model_name,\n",
+    "    namespace=juju_model_name,\n",
     "    gateway_endpoint=gateway_ip\n",
     ")"
    ]
@@ -663,7 +680,7 @@
    ],
    "source": [
     "jsonpath = \"'{.items[0].metadata.name}'\"\n",
-    "main_count = !kubectl logs $(kubectl get pod -lseldon-app=$seldon_deployment_canary_name-main -o jsonpath=$jsonpath) classifier | grep \"root:predict\" | wc -l\n",
+    "main_count = !kubectl -n $juju_model_name logs $(kubectl -n $juju_model_name get pod -lseldon-app=$seldon_deployment_canary_name-main -o jsonpath=$jsonpath) classifier | grep \"root:predict\" | wc -l\n",
     "main_count = main_count[0]\n",
     "print(f\"Number of times main was hit: {main_count}\")"
    ]
@@ -684,7 +701,7 @@
    ],
    "source": [
     "jsonpath = \"'{.items[0].metadata.name}'\"\n",
-    "canary_count = !kubectl logs $(kubectl get pod -lseldon-app=$seldon_deployment_canary_name-canary -o jsonpath=$jsonpath) classifier | grep \"root:predict\" | wc -l\n",
+    "canary_count = !kubectl -n $juju_model_name logs $(kubectl -n $juju_model_name get pod -lseldon-app=$seldon_deployment_canary_name-canary -o jsonpath=$jsonpath) classifier | grep \"root:predict\" | wc -l\n",
     "canary_count = canary_count[0]\n",
     "print(f\"Number of times canary was hit: {canary_count}\")"
    ]
@@ -890,7 +907,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = f\"http://{gateway_ip}/seldon/{model_name}/{seldon_deployment_canary_name}/\"\n",
+    "url = f\"http://{gateway_ip}/seldon/{juju_model_name}/{seldon_deployment_canary_name}/\"\n",
     "authservice_cookie = kubeflow_login(url, username=username, password=password)"
    ]
   },
@@ -920,7 +937,7 @@
     "sc = SeldonClient(\n",
     "    gateway=\"istio\",\n",
     "    deployment_name=seldon_deployment_canary_name,\n",
-    "    namespace=model_name,\n",
+    "    namespace=juju_model_name,\n",
     "    gateway_endpoint=gateway_ip,\n",
     ")"
    ]
@@ -979,7 +996,7 @@
    "source": [
     "import requests\n",
     "cookies = {\"authservice_session\": authservice_cookie}\n",
-    "prediction_endpoint = f\"http://{gateway_ip}/seldon/{model_name}/{seldon_deployment_canary_name}/api/v1.0/predictions\""
+    "prediction_endpoint = f\"http://{gateway_ip}/seldon/{juju_model_name}/{seldon_deployment_canary_name}/api/v1.0/predictions\""
    ]
   },
   {
@@ -1037,13 +1054,13 @@
    ],
    "source": [
     "jsonpath = \"'{.items[0].spec.clusterIP}'\"\n",
-    "classifier_svc_ip=!kubectl get svc -l seldon-deployment-id=$seldon_deployment_name,seldon.io/model=true -o jsonpath=$jsonpath\n",
+    "classifier_svc_ip=!kubectl -n $juju_model_name get svc -l seldon-deployment-id=$seldon_deployment_name,seldon.io/model=true -o jsonpath=$jsonpath\n",
     "classifier_svc_ip = classifier_svc_ip[0]\n",
     "content_type = \"'Content-Type: application/json'\"\n",
     "authservice_cookie_curl = f\"'Cookie: authservice_session={authservice_cookie}'\"\n",
     "data = '\\'{\"data\": { \"ndarray\": [[1]]}}\\''\n",
     "\n",
-    "!curl $gateway_ip/seldon/$model_name/$seldon_deployment_name/api/v1.0/predictions -X POST -H $content_type -H $authservice_cookie_curl -d $data"
+    "!curl $gateway_ip/seldon/$juju_model_name/$seldon_deployment_name/api/v1.0/predictions -X POST -H $content_type -H $authservice_cookie_curl -d $data"
    ]
   }
  ],

--- a/examples/ingress_canary_and_auth.ipynb
+++ b/examples/ingress_canary_and_auth.ipynb
@@ -1,0 +1,1542 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5bb813f8-7ac3-4b29-8a28-565da47baac6",
+   "metadata": {},
+   "source": [
+    "# Summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "972ea5db-33fc-4adf-8c00-37941075077e",
+   "metadata": {},
+   "source": [
+    "This demo shows how to:\n",
+    "* Deploy a model with Seldon and access it through an ingress gateway\n",
+    "* Add Dex authentication to that gateway and access the model with authentication\n",
+    "* Use a Canary Rollout with Seldon and Istio to split predictions across multiple models\n",
+    "\n",
+    "This demo is modified from [this tutorial](https://docs.seldon.io/projects/seldon-core/en/latest/examples/istio_canary.html)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7c1cbea-49ee-4596-b433-725959f97a10",
+   "metadata": {},
+   "source": [
+    "# Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b2e43b61-e997-4278-b5c5-d27ab15024c2",
+   "metadata": {},
+   "source": [
+    "Bootsrap a Juju controller on a Kubernetes cluster, such as shown [here](https://juju.is/docs/olm/microk8s) using Microk8s"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4261b7cc-5f83-4065-9d70-7576af34544a",
+   "metadata": {},
+   "source": [
+    "Deploy the Seldon and Istio charms, defining a default-gateway for Istio and providing the name of that gateway to Seldon:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 67,
+   "id": "5dc1ac1b-a4b3-4d09-a006-83816dd8dd02",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gateway_name = \"seldon-gateway\"\n",
+    "model_name = \"seldon-demo\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7634eaab-f15e-41c2-a31c-edcecdcb8ccd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!juju add-model $model_name\n",
+    "\n",
+    "!juju deploy istio-gateway istio-ingressgateway --trust --kind=ingress\n",
+    "!juju deploy istio-pilot --trust --config default-gateway=$model_name/$gateway_name\n",
+    "!juju relate istio-pilot:istio-pilot istio-ingressgateway:istio-pilot\n",
+    "\n",
+    "!juju deploy seldon-core --config istio-gateway=kubeflow/kubeflow-gateway"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1f253399-4b12-439f-af39-9bd7c8e1fe30",
+   "metadata": {},
+   "source": [
+    "Wait for everything to deploy and settle, then get the gateway IP"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf324f5b-f05d-4571-a788-b3bda95f80a1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# sudo snap install juju-wait\n",
+    "!juju wait -vw"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "id": "e8f22c36-452f-4d2b-9b03-0d5380fb2dac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gateway_ip=!kubectl get svc istio-ingressgateway -o yaml -o jsonpath='{.status.loadBalancer.ingress[0].ip}'\n",
+    "gateway_ip = gateway_ip[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "77cf7aaf-07e5-4140-9782-a938ca45a461",
+   "metadata": {},
+   "source": [
+    "## Helpers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "accdecdb-acec-4d5d-858f-d3af8bd62d1e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from IPython.core.magic import register_line_cell_magic\n",
+    "\n",
+    "@register_line_cell_magic\n",
+    "def writetemplate(line, cell):\n",
+    "    with open(line, \"w\") as f:\n",
+    "        f.write(cell.format(**globals()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ed2b8697-266f-41eb-9e6a-16e4e04f8a7c",
+   "metadata": {},
+   "source": [
+    "# Deploy a Seldon Model and Access it through an Ingress Gateway"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8e965be7-e949-4920-8b4d-bf41d565df9b",
+   "metadata": {},
+   "source": [
+    "### Define and deploy the model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "ee4c614f-d772-4308-886a-014b6a323911",
+   "metadata": {},
+   "source": [
+    "Let's deploy a mock classifier provided by seldon, which will take ndarrays of data and return results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "828228f6-e947-4f95-9a87-fe4ad633db01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seldon_deployment_name = \"sd-example\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "50fc0230-72ec-4d79-9727-d8d44b925368",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writetemplate model.yaml\n",
+    "apiVersion: machinelearning.seldon.io/v1alpha2\n",
+    "kind: SeldonDeployment\n",
+    "metadata:\n",
+    "  labels:\n",
+    "    app: seldon\n",
+    "  name: {seldon_deployment_name}\n",
+    "spec:\n",
+    "  name: example\n",
+    "  predictors:\n",
+    "  - componentSpecs:\n",
+    "    - spec:\n",
+    "        containers:\n",
+    "        - image: seldonio/mock_classifier:1.7.0\n",
+    "          imagePullPolicy: IfNotPresent\n",
+    "          name: classifier\n",
+    "        terminationGracePeriodSeconds: 1\n",
+    "    graph:\n",
+    "      children: []\n",
+    "      endpoint:\n",
+    "        type: REST\n",
+    "      name: classifier\n",
+    "      type: MODEL\n",
+    "    name: main\n",
+    "    replicas: 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "49703c5e-d988-475c-9711-bfd419594cf0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "seldondeployment.machinelearning.seldon.io/sd-example created\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl create -f model.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 64,
+   "id": "5639b998-ddbd-41de-bb3d-fa8d1f3f93d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jsonpath=\"'{.items[0].metadata.name}'\"\n",
+    "deployment_name = !kubectl get deploy -l seldon-deployment-id=$seldon_deployment_name -o jsonpath=$jsonpath\n",
+    "deployment_name = deployment_name[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 65,
+   "id": "0474dda9-30f4-40d9-bb09-30464d92088e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "deployment \"sd-example-main-0-classifier\" successfully rolled out\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl rollout status deploy/$deployment_name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c6ae886f-9dab-4aa4-a52c-8ba7b823895e",
+   "metadata": {},
+   "source": [
+    "### Connect to the deployed model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c5e9e0e-39b6-42c7-b82a-9a47684e5382",
+   "metadata": {},
+   "source": [
+    "#### Using the Seldon Client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 70,
+   "id": "0d86a283-4d77-4ca0-b0c1-5927a1b10279",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:seldon_core.seldon_client:Configuration:{'gateway': 'istio', 'transport': 'rest', 'namespace': 'seldon-demo', 'deployment_name': 'sd-example', 'payload_type': 'tensor', 'gateway_endpoint': '10.64.140.43', 'microservice_endpoint': 'localhost:5000', 'grpc_max_send_message_length': 4194304, 'grpc_max_receive_message_length': 4194304, 'channel_credentials': None, 'call_credentials': None, 'debug': False, 'client_return_type': 'dict', 'ssl': None}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from seldon_core.seldon_client import SeldonClient\n",
+    "\n",
+    "sc = SeldonClient(\n",
+    "    gateway=\"istio\",\n",
+    "    deployment_name=seldon_deployment_name,\n",
+    "    namespace=model_name,\n",
+    "    gateway_endpoint=gateway_ip\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 72,
+   "id": "cf743eb3-ae75-4dc0-9ad2-a6616b04bcf4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.12186205110659878]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Success:True message:\n",
+      "Request:\n",
+      "meta {\n",
+      "}\n",
+      "data {\n",
+      "  tensor {\n",
+      "    shape: 1\n",
+      "    shape: 1\n",
+      "    values: 0.9417526445253931\n",
+      "  }\n",
+      "}\n",
+      "\n",
+      "Response:\n",
+      "{'data': {'names': ['proba'], 'tensor': {'shape': [1, 1], 'values': [0.12186205110659878]}}, 'meta': {'requestPath': {'classifier': 'seldonio/mock_classifier:1.7.0'}}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "r = sc.predict(gateway=\"istio\", transport=\"rest\")\n",
+    "if r.success, r.response\n",
+    "    print(\"Congratulations, prediction returned response:\")\n",
+    "    print(r.response)\n",
+    "else:\n",
+    "    raise ValueError(\"Something went wrong - is the gateway set up correctly?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "id": "1f6ed330-f167-4511-a879-baeb1cf32490",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert r.success, \"Something went wrong - is the gateway set up correctly?\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d19043c4-348c-40e8-ace9-ad4009117abd",
+   "metadata": {},
+   "source": [
+    "#### Using curl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7481e99f-a39c-48fb-bbb9-80d6cf92c8fd",
+   "metadata": {},
+   "source": [
+    "Through `curl`, you can access the classifier deployed by seldon a number of ways:\n",
+    "* direct to the servce:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 81,
+   "id": "34c3e20a-12f7-4ff4-b377-9bc2eb5890b0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"data\":{\"names\":[\"proba\"],\"ndarray\":[[0.12823373759251927]]},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "jsonpath = \"'{.items[0].spec.clusterIP}'\"\n",
+    "classifier_svc_ip=!kubectl get svc -l seldon-deployment-id=$seldon_deployment_name,seldon.io/model=true -o jsonpath=$jsonpath\n",
+    "classifier_svc_ip = classifier_svc_ip[0]\n",
+    "content_type = \"'Content-Type: application/json'\"\n",
+    "data = '\\'{\"data\": { \"ndarray\": [[1]]}}\\''\n",
+    "\n",
+    "!curl $classifier_svc_ip:9000/predict -X POST -H $content_type -d $data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6719ae5f-ddcb-4689-99d8-b1485daba6d2",
+   "metadata": {},
+   "source": [
+    "* via the ingress:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 82,
+   "id": "c834ed1c-1e23-4697-8311-834be1f0a116",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'10.64.140.43'"
+      ]
+     },
+     "execution_count": 82,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "ingress_ip"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 83,
+   "id": "e6f3a995-b86a-464d-9c5e-804c0d189192",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"data\":{\"names\":[\"proba\"],\"ndarray\":[[0.12823373759251927]]},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "!curl $ingress_ip/seldon/$model_name/$seldon_deployment_name/api/v1.0/predictions -X POST -H $content_type -d $data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61734cdc-0806-4a7f-9df6-294fc50679db",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22b5fd43-ab99-4324-b16f-342e03737d1f",
+   "metadata": {},
+   "source": [
+    "# Deploy a Canary Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4907f4ce-e8ee-4caa-9f28-9ba5171dccdc",
+   "metadata": {},
+   "source": [
+    "### Define and deploy the model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0fc0b369-adda-4492-89c5-6b379bd8904b",
+   "metadata": {},
+   "source": [
+    "In this SeldonDeployment, we define two models, `main` and `canary`, with a traffic split of 75:25, respectively."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 84,
+   "id": "188f4b80-ccb3-417c-918a-1e16fea18a01",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seldon_deployment_name = \"sd-example-canary\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 85,
+   "id": "a9d796dc-396b-407c-add5-7e598263dc1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%writetemplate canary.yaml\n",
+    "apiVersion: machinelearning.seldon.io/v1alpha2\n",
+    "kind: SeldonDeployment\n",
+    "metadata:\n",
+    "  labels:\n",
+    "    app: seldon\n",
+    "  name: {seldon_deployment_name}\n",
+    "spec:\n",
+    "  name: canary-example\n",
+    "  predictors:\n",
+    "  - componentSpecs:\n",
+    "    - spec:\n",
+    "        containers:\n",
+    "        - image: seldonio/mock_classifier:1.7.0\n",
+    "          imagePullPolicy: IfNotPresent\n",
+    "          name: classifier\n",
+    "        terminationGracePeriodSeconds: 1\n",
+    "    graph:\n",
+    "      children: []\n",
+    "      endpoint:\n",
+    "        type: REST\n",
+    "      name: classifier\n",
+    "      type: MODEL\n",
+    "    name: main\n",
+    "    replicas: 1\n",
+    "    traffic: 75\n",
+    "  - componentSpecs:\n",
+    "    - spec:\n",
+    "        containers:\n",
+    "        - image: seldonio/mock_classifier:1.7.0\n",
+    "          imagePullPolicy: IfNotPresent\n",
+    "          name: classifier\n",
+    "        terminationGracePeriodSeconds: 1\n",
+    "    graph:\n",
+    "      children: []\n",
+    "      endpoint:\n",
+    "        type: REST\n",
+    "      name: classifier\n",
+    "      type: MODEL\n",
+    "    name: canary\n",
+    "    replicas: 1\n",
+    "    traffic: 25"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 87,
+   "id": "8092dacf-7204-4256-9828-5e65c39981e5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "seldondeployment.machinelearning.seldon.io/sd-example-canary created\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl create -f canary.yaml"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 88,
+   "id": "7304dde3-1672-4a00-847d-6540f8b68aba",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jsonpath=\"'{.items[0].metadata.name}'\"\n",
+    "deployment_name = !kubectl get deploy -l seldon-deployment-id=$seldon_deployment_name -o jsonpath=$jsonpath\n",
+    "deployment_name = deployment_name[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 89,
+   "id": "3f1073f6-2e3c-4a6f-ad66-970fa5b076b8",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Waiting for deployment \"sd-example-canary-canary-0-classifier\" rollout to finish: 0 of 1 updated replicas are available...\n",
+      "deployment \"sd-example-canary-canary-0-classifier\" successfully rolled out\n"
+     ]
+    }
+   ],
+   "source": [
+    "!kubectl rollout status deploy/$deployment_name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26caadbe-e11c-4752-b91c-204e0c863a15",
+   "metadata": {},
+   "source": [
+    "### Connect to the deployed model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1d4ab354-326a-47d5-96ec-d6c9b39386d4",
+   "metadata": {},
+   "source": [
+    "#### Using the Seldon Client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a04ffcca-b66b-4e09-949d-b86dba5e23a6",
+   "metadata": {},
+   "source": [
+    "Hit the endpoint multiple times so that we can see if it is distributing the load as desired"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "id": "6c4256f7-a279-48b7-82e7-ca3a5a60104b",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:seldon_core.seldon_client:Configuration:{'gateway': 'istio', 'transport': 'rest', 'namespace': 'seldon-demo', 'deployment_name': 'sd-example-canary', 'payload_type': 'tensor', 'gateway_endpoint': '10.64.140.43', 'microservice_endpoint': 'localhost:5000', 'grpc_max_send_message_length': 4194304, 'grpc_max_receive_message_length': 4194304, 'channel_credentials': None, 'call_credentials': None, 'debug': False, 'client_return_type': 'dict', 'ssl': None}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from seldon_core.seldon_client import SeldonClient\n",
+    "\n",
+    "sc = SeldonClient(\n",
+    "    gateway=\"istio\",\n",
+    "    deployment_name=seldon_deployment_name,\n",
+    "    namespace=model_name,\n",
+    "    gateway_endpoint=gateway_ip\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 92,
+   "id": "639d8504-9d6d-4c7f-9cdf-aff43c2cb0b0",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05554955731239537]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.0870091499295114]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 157\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.052991143682868024]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08030132858376389]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06312795484024333]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08322240364505004]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.12544973129668835]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.12129177432039209]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07983221851710066]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 154\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.073658974426667]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06580302274253211]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08695038972523683]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06858469089618405]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07217343029641078]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07470544031875946]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 157\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.058333418343276704]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05152170715365609]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06121129361149572]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06857070672968726]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10774019502564221]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06761406436822569]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.09743201468539289]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.1260322252524635]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08285770846960563]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05720513302090965]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06433972382247694]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10026297834752762]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06632253798384825]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.11074646566263582]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05219818300484121]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05628205654827272]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08997712013218655]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08556230573956275]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06668995480396316]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06347389425108753]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07613014744330177]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07847743093627758]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06336165281563878]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07463382405638495]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05601599338233754]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05814908897704056]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08131847959049344]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08514375445885225]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.1211884926417159]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.1165568657525379]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.1159252415028424]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07166529668768763]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07103815006946987]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07532612193018186]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07020615822748993]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08194110933214269]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06960763670854465]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10027648973261799]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10104636795020713]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10942147525324357]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06718163856816584]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.09305362516760812]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 157\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.057274194663729454]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.12426070819309708]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.1026280133964406]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08368088833585935]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.11864869870265946]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.1112185201291976]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10483848024291785]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 157\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.055262039417025476]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10885385162473729]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08033365438942365]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07231858767684424]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07287685898568622]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10134426287153236]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.0699643733580762]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06134548029691366]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07813319633053682]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.11453192636066012]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05852696575071936]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 157\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.059411958186982916]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 157\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.061870262265794264]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.12794016477935458]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.1034049285384411]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.09062851527194803]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05882648098885694]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.1181650564247353]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06205659777824486]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.0534543510995789]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05318001101872843]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07990267716883673]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.09432725499632359]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10417186490362211]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.12818773506490352]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06191218287079697]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10381087351072414]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.09961087857645234]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06737044260209733]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.09603014194721878]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06652441482784867]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06999814668729944]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.09677246172792608]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08992512205290529]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.11925995809948013]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n",
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07536681430678654]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "for _ in range(100):\n",
+    "    r = sc.predict(gateway=\"istio\", transport=\"rest\")\n",
+    "    assert r.success, \"Something went wrong - is the gateway set up correctly?\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2baeb357-1b1c-404b-a13b-620f73ec3a84",
+   "metadata": {},
+   "source": [
+    "We can parse the logs of the `main` and `canary` pods to see how many times each has been hit to demonstrate the traffic split"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 96,
+   "id": "cdb54a37-4674-4add-9ab6-ffea214caf3a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jsonpath = \"'{.items[0].metadata.name}'\"\n",
+    "main_count = !kubectl logs $(kubectl get pod -lseldon-app=$seldon_deployment_name-main -o jsonpath=$jsonpath) classifier | grep \"root:predict\" | wc -l\n",
+    "main_count = main_count[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 97,
+   "id": "66ce5eee-5a6a-4d3b-99da-834b4258c91c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jsonpath = \"'{.items[0].metadata.name}'\"\n",
+    "canary_count = !kubectl logs $(kubectl get pod -lseldon-app=$seldon_deployment_name-canary -o jsonpath=$jsonpath) classifier | grep \"root:predict\" | wc -l\n",
+    "canary_count = canary_count[0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 98,
+   "id": "0c369ff0-bd40-4268-8542-ecff41a0452e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of times main was hit: 67\n",
+      "Number of times canary was hit: 33\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"Number of times main was hit: {main_count}\")\n",
+    "print(f\"Number of times canary was hit: {canary_count}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7cebe6fc-3020-42e6-b3bd-57e78b64f010",
+   "metadata": {},
+   "source": [
+    "# Access with Authentication"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9c8d3e3e-9dea-4f55-aad4-1193887101ee",
+   "metadata": {},
+   "source": [
+    "If we protect our ingress with Dex+OIDC Gatekeeper, unauthenticated access will be rejected.  Below is a method for programatically authenticating and hitting the prediction endpoints."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22663cca-b831-45a3-bc6f-36dc7ffbb406",
+   "metadata": {},
+   "source": [
+    "## Authentication Setup"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01f3f23c-6949-469e-b60a-63ecd0e18de2",
+   "metadata": {},
+   "source": [
+    "By adding the `dex-auth` and `oidc-gatekeeper` charms and setting the credentials and `public-url` configurations, we can add authentication to our existing ingress gateway"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 105,
+   "id": "1a646a06-6cf0-46bc-8af4-c9abdc95b110",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "username=\"admin\"\n",
+    "password=\"admin\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 100,
+   "id": "59b84e27-3720-4ffc-84b3-970cad2ab217",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Located charm \"dex-auth\" in charm-hub, revision 78\n",
+      "Deploying \"dex-auth\" from charm-hub charm \"dex-auth\", revision 78 in channel 2.28/stable\n",
+      "Located charm \"oidc-gatekeeper\" in charm-hub, revision 57\n",
+      "Deploying \"oidc-gatekeeper\" from charm-hub charm \"oidc-gatekeeper\", revision 57 in channel stable\n"
+     ]
+    }
+   ],
+   "source": [
+    "!juju deploy dex-auth --trust --config static-username=$username --config static-password=$password --config public-url=$ingress_ip\n",
+    "!juju deploy oidc-gatekeeper --config public-url=$ingress_ip\n",
+    "\n",
+    "!juju relate dex-auth oidc-gatekeeper\n",
+    "!juju relate dex-auth istio-pilot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 101,
+   "id": "cc8b274f-9904-4aac-b34c-daa18b7a698f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:root:dex-auth/0 workload status is maintenance since 2022-02-25 22:20:46+00:00\n",
+      "DEBUG:root:dex-auth/0 juju agent status is executing since 2022-02-25 22:20:46+00:00\n",
+      "DEBUG:root:oidc-gatekeeper/0 juju agent status is allocating since 2022-02-25 22:20:34+00:00\n",
+      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:20:53+00:00\n",
+      "DEBUG:root:dex-auth/0 juju agent status is executing since 2022-02-25 22:20:46+00:00\n",
+      "DEBUG:root:oidc-gatekeeper/0 juju agent status is executing since 2022-02-25 22:20:54+00:00\n",
+      "DEBUG:root:dex-auth/0 workload status is waiting since 2022-02-25 22:20:57+00:00\n",
+      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:20:58+00:00\n",
+      "DEBUG:root:dex-auth/0 juju agent status is executing since 2022-02-25 22:20:58+00:00\n",
+      "DEBUG:root:istio-pilot/0 juju agent status is executing since 2022-02-25 22:20:57+00:00\n",
+      "DEBUG:root:oidc-gatekeeper/0 juju agent status is executing since 2022-02-25 22:20:56+00:00\n",
+      "DEBUG:root:istio-pilot/0 workload status is maintenance since 2022-02-25 22:21:02+00:00\n",
+      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:20:58+00:00\n",
+      "DEBUG:root:dex-auth/0 juju agent status is executing since 2022-02-25 22:21:02+00:00\n",
+      "DEBUG:root:istio-pilot/0 juju agent status is executing since 2022-02-25 22:21:00+00:00\n",
+      "DEBUG:root:oidc-gatekeeper/0 juju agent status is executing since 2022-02-25 22:21:00+00:00\n",
+      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:21:05+00:00\n",
+      "DEBUG:root:dex-auth/0 juju agent status is executing since 2022-02-25 22:21:06+00:00\n",
+      "DEBUG:root:istio-pilot/0 juju agent status is executing since 2022-02-25 22:21:06+00:00\n",
+      "DEBUG:root:oidc-gatekeeper/0 juju agent status is executing since 2022-02-25 22:21:04+00:00\n",
+      "DEBUG:root:dex-auth/0 workload status is maintenance since 2022-02-25 22:21:11+00:00\n",
+      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:21:05+00:00\n",
+      "DEBUG:root:dex-auth/0 juju agent status is executing since 2022-02-25 22:21:10+00:00\n",
+      "DEBUG:root:oidc-gatekeeper/0 juju agent status is executing since 2022-02-25 22:21:07+00:00\n",
+      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:21:15+00:00\n",
+      "DEBUG:root:dex-auth/0 juju agent status is executing since 2022-02-25 22:21:15+00:00\n",
+      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:21:15+00:00\n",
+      "DEBUG:root:dex-auth/0 juju agent status is executing since 2022-02-25 22:21:18+00:00\n",
+      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:21:15+00:00\n",
+      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:21:15+00:00\n",
+      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:21:15+00:00\n",
+      "^C\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/snap/juju-wait/96/bin/juju-wait\", line 33, in <module>\n"
+     ]
+    }
+   ],
+   "source": [
+    "!juju wait -vw"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72175420-43e1-4cbd-b056-5372d662dbdc",
+   "metadata": {},
+   "source": [
+    "To authenticate and obtain a authorization cookie, use the `kubeflow_login` helper.  For the url, you can use any valid url that has a VirtualService passing traffic through, such as the models we are serving."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "id": "ba561515-d24b-49e5-a844-78cd60817aae",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Helpers for authentication\n",
+    "\n",
+    "import logging\n",
+    "import requests\n",
+    "from urllib.parse import parse_qs, urlparse\n",
+    "\n",
+    "def kubeflow_login(url, username=None, password=None):\n",
+    "    \"\"\"Completes the dex/oidc login flow, returning the authservice_session cookie.\"\"\"\n",
+    "    parsed_url = urlparse(url)\n",
+    "    url_base = f\"{parsed_url.scheme}://{parsed_url.netloc}\"\n",
+    "    \n",
+    "    data = {\n",
+    "        'login': username or os.getenv('KUBEFLOW_USERNAME', None),\n",
+    "        'password': password or os.getenv('KUBEFLOW_PASSWORD', None),\n",
+    "    }\n",
+    "\n",
+    "    if not data['login'] or not data['password']:\n",
+    "        raise ValueError(\n",
+    "            \"Missing login credentials - credentials must be passed or defined\"\n",
+    "            \" in KUBEFLOW_USERNAME/KUBEFLOW_PASSWORD environment variables.\"\n",
+    "        )\n",
+    "\n",
+    "    # GET on url redirects us to the dex_login_url including state for this session\n",
+    "    response = requests.get(\n",
+    "        url,\n",
+    "        verify=False,\n",
+    "        allow_redirects=True\n",
+    "    )\n",
+    "    validate_response_status_code(response, [200], f\"Failed to connect to url site '{url}'.\")\n",
+    "    dex_login_url = response.url\n",
+    "    logging.debug(f\"Redirected to dex_login_url of '{dex_login_url}'\")\n",
+    "    \n",
+    "    # Log in, retrieving the redirection to the approval page\n",
+    "    response = requests.post(\n",
+    "        dex_login_url,\n",
+    "        data=data,\n",
+    "        verify=False,\n",
+    "        allow_redirects=False\n",
+    "    )\n",
+    "    validate_response_status_code(\n",
+    "        response, [303], f\"Failed to log into dex - are your credentials correct?\"\n",
+    "    )\n",
+    "    approval_endpoint = response.headers['location']\n",
+    "    dex_approval_url = url_base + approval_endpoint\n",
+    "    logging.debug(f\"Logged in with dex_approval_url of '{dex_approval_url}\")\n",
+    "    \n",
+    "    # Get the OIDC approval code and state\n",
+    "    response = requests.get(\n",
+    "        dex_approval_url,\n",
+    "        verify=False,\n",
+    "        allow_redirects=False\n",
+    "    )\n",
+    "    validate_response_status_code(\n",
+    "        response, [303], f\"Failed to connect to dex_approval_url '{dex_approval_url}'.\"\n",
+    "    )\n",
+    "    authservice_endpoint = response.headers['location']\n",
+    "    authservice_url = url_base + authservice_endpoint\n",
+    "    logging.debug(f\"Got authservice_url of '{authservice_url}'\")\n",
+    "\n",
+    "    \n",
+    "    # Access DEX OIDC path to generate session cookie\n",
+    "    response = requests.get(\n",
+    "        authservice_url,\n",
+    "        verify=False,\n",
+    "        allow_redirects=False,\n",
+    "    )\n",
+    "    validate_response_status_code(\n",
+    "        response, [302], f\"Failed to connect to authservice_url '{authservice_url}'.\"\n",
+    "    )\n",
+    "    \n",
+    "    return response.cookies['authservice_session']\n",
+    "    \n",
+    "    \n",
+    "def validate_response_status_code(response, expected_codes: list, error_message: str = \"\"):\n",
+    "    \"\"\"Validates the status code of a response, raising a ValueError with message\"\"\"\n",
+    "    if error_message:\n",
+    "        error_message += \"  \"\n",
+    "    if response.status_code not in expected_codes:\n",
+    "        raise ValueError(\n",
+    "            f\"{error_message}\"\n",
+    "            f\"Got response {response.status_code}, expected one of {expected_codes}\"\n",
+    "        )\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 106,
+   "id": "2d72289b-27cc-4570-a16f-795e39735b92",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"GET /seldon/seldon-demo/sd-example-canary/ HTTP/1.1\" 404 19\n"
+     ]
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "Failed to connect to url site 'http://10.64.140.43/seldon/seldon-demo/sd-example-canary/'.  Got response 404, expected one of [200]",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m/tmp/ipykernel_536803/570625492.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0murl\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34mf\"http://{gateway_ip}/seldon/{model_name}/{seldon_deployment_name}/\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mauthservice_cookie\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mkubeflow_login\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0murl\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0musername\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0musername\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpassword\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mpassword\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m/tmp/ipykernel_536803/1191261482.py\u001b[0m in \u001b[0;36mkubeflow_login\u001b[0;34m(url, username, password)\u001b[0m\n\u001b[1;32m     27\u001b[0m         \u001b[0mallow_redirects\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     28\u001b[0m     )\n\u001b[0;32m---> 29\u001b[0;31m     \u001b[0mvalidate_response_status_code\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresponse\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;36m200\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34mf\"Failed to connect to url site '{url}'.\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     30\u001b[0m     \u001b[0mdex_login_url\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0murl\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     31\u001b[0m     \u001b[0mlogging\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdebug\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"Redirected to dex_login_url of '{dex_login_url}'\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m/tmp/ipykernel_536803/1191261482.py\u001b[0m in \u001b[0;36mvalidate_response_status_code\u001b[0;34m(response, expected_codes, error_message)\u001b[0m\n\u001b[1;32m     77\u001b[0m         \u001b[0merror_message\u001b[0m \u001b[0;34m+=\u001b[0m \u001b[0;34m\"  \"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     78\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstatus_code\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mexpected_codes\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 79\u001b[0;31m         raise ValueError(\n\u001b[0m\u001b[1;32m     80\u001b[0m             \u001b[0;34mf\"{error_message}\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     81\u001b[0m             \u001b[0;34mf\"Got response {response.status_code}, expected one of {expected_codes}\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: Failed to connect to url site 'http://10.64.140.43/seldon/seldon-demo/sd-example-canary/'.  Got response 404, expected one of [200]"
+     ]
+    }
+   ],
+   "source": [
+    "url = f\"http://{gateway_ip}/seldon/{model_name}/{seldon_deployment_name}/\"\n",
+    "authservice_cookie = kubeflow_login(url, username=username, password=password)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bae5b18-00dc-4ed3-8dc5-6ba4fd8b58db",
+   "metadata": {},
+   "source": [
+    "And use the cookie in our seldon client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 91,
+   "id": "4b42dbbc-6465-4ce5-ab6f-fc34739a5383",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:seldon_core.seldon_client:Configuration:{'gateway': 'istio', 'transport': 'rest', 'namespace': 'seldon-demo', 'deployment_name': 'sd-example-canary', 'payload_type': 'tensor', 'gateway_endpoint': '10.64.140.43', 'microservice_endpoint': 'localhost:5000', 'grpc_max_send_message_length': 4194304, 'grpc_max_receive_message_length': 4194304, 'channel_credentials': None, 'call_credentials': None, 'debug': False, 'client_return_type': 'dict', 'ssl': None}\n"
+     ]
+    }
+   ],
+   "source": [
+    "from seldon_core.seldon_client import SeldonClient\n",
+    "\n",
+    "sc = SeldonClient(\n",
+    "    gateway=\"istio\",\n",
+    "    deployment_name=seldon_deployment_name,\n",
+    "    namespace=model_name,\n",
+    "    gateway_endpoint=gateway_ip\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0f5546b8-060b-4cb2-b49f-45626da2765d",
+   "metadata": {},
+   "source": [
+    "# Continue with this: \n",
+    "https://docs.seldon.io/projects/seldon-core/en/latest/examples/seldon_client.html"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "id": "74ba372b-b92b-4fc9-8c6f-82103acf9d8c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
+      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
+      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 157\n",
+      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.055356987829593515]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "r = sc.predict(gateway=\"istio\", transport=\"rest\")\n",
+    "if r.success, r.response\n",
+    "    print(\"Congratulations, prediction returned response:\")\n",
+    "    print(r.response)\n",
+    "else:\n",
+    "    raise ValueError(\"Something went wrong - is the gateway set up correctly?\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b37cc480-91a0-4039-92be-a207ef4fcecb",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "seldon-istio-venv",
+   "language": "python",
+   "name": "seldon-istio-venv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/ingress_canary_and_auth.ipynb
+++ b/examples/ingress_canary_and_auth.ipynb
@@ -1060,7 +1060,7 @@
     "authservice_cookie_curl = f\"'Cookie: authservice_session={authservice_cookie}'\"\n",
     "data = '\\'{\"data\": { \"ndarray\": [[1]]}}\\''\n",
     "\n",
-    "!curl $gateway_ip/seldon/$juju_model_name/$seldon_deployment_name/api/v1.0/predictions -X POST -H $content_type -H $authservice_cookie_curl -d $data"
+    "!curl $gateway_ip/seldon/$juju_model_name/$seldon_deployment_name/api/v1.0/predictions -X POST -H $content_type -H $authservice_cookie_curl -d $data\n"
    ]
   }
  ],

--- a/examples/ingress_canary_and_auth.ipynb
+++ b/examples/ingress_canary_and_auth.ipynb
@@ -78,7 +78,7 @@
     "\n",
     "!juju deploy istio-gateway istio-ingressgateway --trust --channel 1.5/stable\n",
     "!juju deploy istio-pilot --trust --config default-gateway=$gateway_name --channel 1.5/stable\n",
-    "# !juju deploy istio-gateway istio-ingressgateway --trust --kind=ingress\n",
+    "# !juju deploy istio-gateway istio-ingressgateway --trust --config kind=ingress\n",
     "# !juju deploy istio-pilot --trust --config default-gateway=$gateway_name\n",
     "\n",
     "!juju relate istio-pilot:istio-pilot istio-ingressgateway:istio-pilot\n",
@@ -253,7 +253,7 @@
     }
    ],
    "source": [
-    "!kubectl create -f model.yaml"
+    "!kubectl -n $juju_model_name create -f model.yaml"
    ]
   },
   {

--- a/examples/ingress_canary_and_auth.ipynb
+++ b/examples/ingress_canary_and_auth.ipynb
@@ -14,9 +14,9 @@
    "metadata": {},
    "source": [
     "This demo shows how to:\n",
-    "* Deploy a model with Seldon and access it through an ingress gateway\n",
-    "* Add Dex authentication to that gateway and access the model with authentication\n",
+    "* Deploy a model with Seldon and access it through an ingress gateway using the Seldon client, curl, and other methods\n",
     "* Use a Canary Rollout with Seldon and Istio to split predictions across multiple models\n",
+    "* Protect your model endpoints behind Dex, adding a requirement for authentication to access the model through the external gateway\n",
     "\n",
     "This demo is modified from [this tutorial](https://docs.seldon.io/projects/seldon-core/en/latest/examples/istio_canary.html)"
    ]
@@ -47,13 +47,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 67,
+   "execution_count": 1,
    "id": "5dc1ac1b-a4b3-4d09-a006-83816dd8dd02",
    "metadata": {},
    "outputs": [],
    "source": [
     "gateway_name = \"seldon-gateway\"\n",
-    "model_name = \"seldon-demo\""
+    "model_name = \"seldon-model\""
    ]
   },
   {
@@ -69,7 +69,7 @@
     "!juju deploy istio-pilot --trust --config default-gateway=$model_name/$gateway_name\n",
     "!juju relate istio-pilot:istio-pilot istio-ingressgateway:istio-pilot\n",
     "\n",
-    "!juju deploy seldon-core --config istio-gateway=kubeflow/kubeflow-gateway"
+    "!juju deploy seldon-core --config istio-gateway=$model_name/$gateway_name"
    ]
   },
   {
@@ -82,10 +82,29 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "cf324f5b-f05d-4571-a788-b3bda95f80a1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "DEBUG:root:istio-ingressgateway/2 workload status is waiting since 2022-02-28 19:18:05+00:00\n",
+      "DEBUG:root:istio-pilot/2 workload status is maintenance since 2022-02-28 19:18:07+00:00\n",
+      "DEBUG:root:istio-pilot/2 juju agent status is executing since 2022-02-28 19:18:06+00:00\n",
+      "DEBUG:root:istio-ingressgateway/2 workload status is waiting since 2022-02-28 19:18:05+00:00\n",
+      "DEBUG:root:istio-ingressgateway/2 workload status is waiting since 2022-02-28 19:18:12+00:00\n",
+      "DEBUG:root:istio-pilot/2 workload status is maintenance since 2022-02-28 19:18:28+00:00\n",
+      "INFO:root:All units idle since 2022-02-28 19:18:33.363252Z (dex-auth/5, istio-ingressgateway/2, istio-pilot/2, oidc-gatekeeper/1, seldon-controller-manager/1)\n",
+      "DEBUG:root:dex-auth is lead by dex-auth/5\n",
+      "DEBUG:root:istio-ingressgateway is lead by istio-ingressgateway/2\n",
+      "DEBUG:root:istio-pilot is lead by istio-pilot/2\n",
+      "DEBUG:root:oidc-gatekeeper is lead by oidc-gatekeeper/1\n",
+      "DEBUG:root:seldon-controller-manager is lead by seldon-controller-manager/1\n"
+     ]
+    }
+   ],
    "source": [
     "# sudo snap install juju-wait\n",
     "!juju wait -vw"
@@ -93,13 +112,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 69,
+   "execution_count": 4,
    "id": "e8f22c36-452f-4d2b-9b03-0d5380fb2dac",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Our Istio ingressgateway ip: 10.64.140.43\n"
+     ]
+    }
+   ],
    "source": [
     "gateway_ip=!kubectl get svc istio-ingressgateway -o yaml -o jsonpath='{.status.loadBalancer.ingress[0].ip}'\n",
-    "gateway_ip = gateway_ip[0]"
+    "gateway_ip = gateway_ip[0]\n",
+    "print(f\"Our Istio ingressgateway ip: {gateway_ip}\")"
    ]
   },
   {
@@ -112,7 +140,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 5,
    "id": "accdecdb-acec-4d5d-858f-d3af8bd62d1e",
    "metadata": {},
    "outputs": [],
@@ -151,7 +179,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 6,
    "id": "828228f6-e947-4f95-9a87-fe4ad633db01",
    "metadata": {},
    "outputs": [],
@@ -161,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 7,
    "id": "50fc0230-72ec-4d79-9727-d8d44b925368",
    "metadata": {},
    "outputs": [],
@@ -195,7 +223,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 8,
    "id": "49703c5e-d988-475c-9711-bfd419594cf0",
    "metadata": {},
    "outputs": [
@@ -213,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 64,
+   "execution_count": 9,
    "id": "5639b998-ddbd-41de-bb3d-fa8d1f3f93d7",
    "metadata": {},
    "outputs": [],
@@ -225,7 +253,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 65,
+   "execution_count": 10,
    "id": "0474dda9-30f4-40d9-bb09-30464d92088e",
    "metadata": {},
    "outputs": [
@@ -233,6 +261,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "Waiting for deployment \"sd-example-main-0-classifier\" rollout to finish: 0 of 1 updated replicas are available...\n",
       "deployment \"sd-example-main-0-classifier\" successfully rolled out\n"
      ]
     }
@@ -246,7 +275,15 @@
    "id": "c6ae886f-9dab-4aa4-a52c-8ba7b823895e",
    "metadata": {},
    "source": [
-    "### Connect to the deployed model"
+    "### Predict using the deployed model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75540672-0a0b-49dc-9508-933a21a17dc0",
+   "metadata": {},
+   "source": [
+    "Seldon deploys a rest (and GRPC) endpoint to connect to for predictions.  Below are a few examples of how to get the model to make predictions."
    ]
   },
   {
@@ -259,18 +296,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 70,
+   "execution_count": 11,
    "id": "0d86a283-4d77-4ca0-b0c1-5927a1b10279",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "DEBUG:seldon_core.seldon_client:Configuration:{'gateway': 'istio', 'transport': 'rest', 'namespace': 'seldon-demo', 'deployment_name': 'sd-example', 'payload_type': 'tensor', 'gateway_endpoint': '10.64.140.43', 'microservice_endpoint': 'localhost:5000', 'grpc_max_send_message_length': 4194304, 'grpc_max_receive_message_length': 4194304, 'channel_credentials': None, 'call_credentials': None, 'debug': False, 'client_return_type': 'dict', 'ssl': None}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from seldon_core.seldon_client import SeldonClient\n",
     "\n",
@@ -283,60 +312,42 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "443136ae-7ca3-4a1d-954f-8f68ddfacab2",
+   "metadata": {},
+   "source": [
+    "\"Predict\" with our model.  If we don't specify any data in the `.predict()` call, Seldon sends a single dummy value to our \"model\".  \n",
+    "\n",
+    "If successful, the return `r.response` should look something like:\n",
+    "```\n",
+    "{'data': {'names': ['proba'], 'tensor': {'shape': [1, 1], 'values': [SOME_VALUE]}}, 'meta': {'requestPath': {'classifier': 'seldonio/mock_classifier:1.7.0'}}}\n",
+    "```\n",
+    "\n",
+    "where `SOME_VALUE` is the returned prediction."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 72,
+   "execution_count": 12,
    "id": "cf743eb3-ae75-4dc0-9ad2-a6616b04bcf4",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.12186205110659878]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Success:True message:\n",
-      "Request:\n",
-      "meta {\n",
-      "}\n",
-      "data {\n",
-      "  tensor {\n",
-      "    shape: 1\n",
-      "    shape: 1\n",
-      "    values: 0.9417526445253931\n",
-      "  }\n",
-      "}\n",
-      "\n",
-      "Response:\n",
-      "{'data': {'names': ['proba'], 'tensor': {'shape': [1, 1], 'values': [0.12186205110659878]}}, 'meta': {'requestPath': {'classifier': 'seldonio/mock_classifier:1.7.0'}}}\n"
+      "Congratulations, prediction returned response:\n",
+      "{'data': {'names': ['proba'], 'tensor': {'shape': [1, 1], 'values': [0.0593137795410493]}}, 'meta': {'requestPath': {'classifier': 'seldonio/mock_classifier:1.7.0'}}}\n"
      ]
     }
    ],
    "source": [
     "r = sc.predict(gateway=\"istio\", transport=\"rest\")\n",
-    "if r.success, r.response\n",
+    "if r.success:\n",
     "    print(\"Congratulations, prediction returned response:\")\n",
     "    print(r.response)\n",
     "else:\n",
     "    raise ValueError(\"Something went wrong - is the gateway set up correctly?\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 76,
-   "id": "1f6ed330-f167-4511-a879-baeb1cf32490",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "assert r.success, \"Something went wrong - is the gateway set up correctly?\""
    ]
   },
   {
@@ -358,7 +369,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 81,
+   "execution_count": 13,
    "id": "34c3e20a-12f7-4ff4-b377-9bc2eb5890b0",
    "metadata": {},
    "outputs": [
@@ -390,28 +401,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 82,
-   "id": "c834ed1c-1e23-4697-8311-834be1f0a116",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'10.64.140.43'"
-      ]
-     },
-     "execution_count": 82,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "ingress_ip"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 83,
+   "execution_count": 14,
    "id": "e6f3a995-b86a-464d-9c5e-804c0d189192",
    "metadata": {},
    "outputs": [
@@ -424,16 +414,16 @@
     }
    ],
    "source": [
-    "!curl $ingress_ip/seldon/$model_name/$seldon_deployment_name/api/v1.0/predictions -X POST -H $content_type -d $data"
+    "!curl $gateway_ip/seldon/$model_name/$seldon_deployment_name/api/v1.0/predictions -X POST -H $content_type -d $data"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "61734cdc-0806-4a7f-9df6-294fc50679db",
+   "cell_type": "markdown",
+   "id": "674ca02a-6a0d-4cea-991d-f6a9f5ca07e4",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "Similarly, you could use any method that lets you hit a REST endpoint to make predictions (for example, using the `requests` package)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -441,6 +431,14 @@
    "metadata": {},
    "source": [
     "# Deploy a Canary Model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6d5c194a-a8ad-47c5-8663-935c367f308b",
+   "metadata": {},
+   "source": [
+    "Sometimes it is useful to simultaneously release multiple models to be served by the same `SeldonDeployment`.  An example of this is when we are releasing a new version of the model and want to first track its performance in the wild using a small portion of our traffic.  This can be done by adding multiple predictors in our `SeldonDeployment`.  An example of this is shown below"
    ]
   },
   {
@@ -456,22 +454,22 @@
    "id": "0fc0b369-adda-4492-89c5-6b379bd8904b",
    "metadata": {},
    "source": [
-    "In this SeldonDeployment, we define two models, `main` and `canary`, with a traffic split of 75:25, respectively."
+    "In this SeldonDeployment, we define two models, `main` and `canary`, with a traffic split of 75:25, respectively.  Note that in this example both the `main` and `canary` predictors use the same model (same image, configuration, etc), but in practice these would be different models."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 84,
+   "execution_count": 15,
    "id": "188f4b80-ccb3-417c-918a-1e16fea18a01",
    "metadata": {},
    "outputs": [],
    "source": [
-    "seldon_deployment_name = \"sd-example-canary\""
+    "seldon_deployment_canary_name = \"sd-example-canary\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 85,
+   "execution_count": 16,
    "id": "a9d796dc-396b-407c-add5-7e598263dc1d",
    "metadata": {},
    "outputs": [],
@@ -482,7 +480,7 @@
     "metadata:\n",
     "  labels:\n",
     "    app: seldon\n",
-    "  name: {seldon_deployment_name}\n",
+    "  name: {seldon_deployment_canary_name}\n",
     "spec:\n",
     "  name: canary-example\n",
     "  predictors:\n",
@@ -522,7 +520,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 87,
+   "execution_count": 17,
    "id": "8092dacf-7204-4256-9828-5e65c39981e5",
    "metadata": {},
    "outputs": [
@@ -540,19 +538,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 88,
+   "execution_count": 18,
    "id": "7304dde3-1672-4a00-847d-6540f8b68aba",
    "metadata": {},
    "outputs": [],
    "source": [
     "jsonpath=\"'{.items[0].metadata.name}'\"\n",
-    "deployment_name = !kubectl get deploy -l seldon-deployment-id=$seldon_deployment_name -o jsonpath=$jsonpath\n",
+    "deployment_name = !kubectl get deploy -l seldon-deployment-id=$seldon_deployment_canary_name -o jsonpath=$jsonpath\n",
     "deployment_name = deployment_name[0]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 89,
+   "execution_count": 19,
    "id": "3f1073f6-2e3c-4a6f-ad66-970fa5b076b8",
    "metadata": {},
    "outputs": [
@@ -560,8 +558,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Waiting for deployment \"sd-example-canary-canary-0-classifier\" rollout to finish: 0 of 1 updated replicas are available...\n",
-      "deployment \"sd-example-canary-canary-0-classifier\" successfully rolled out\n"
+      "Waiting for deployment \"sd-example-canary-main-0-classifier\" rollout to finish: 0 of 1 updated replicas are available...\n",
+      "deployment \"sd-example-canary-main-0-classifier\" successfully rolled out\n"
      ]
     }
    ],
@@ -574,7 +572,15 @@
    "id": "26caadbe-e11c-4752-b91c-204e0c863a15",
    "metadata": {},
    "source": [
-    "### Connect to the deployed model"
+    "### Predict using the deployed models, observing the load split between them"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9191b3f3-09f8-4398-b78f-6af9ec5a632b",
+   "metadata": {},
+   "source": [
+    "As users of the `SeldonDeployment`, we request/receive predictions exactly the same as above.  To the user there is no difference, but on the backend we can see that Seldon (using Istio) has split the load between our `main` and `canary` models."
    ]
   },
   {
@@ -590,29 +596,21 @@
    "id": "a04ffcca-b66b-4e09-949d-b86dba5e23a6",
    "metadata": {},
    "source": [
-    "Hit the endpoint multiple times so that we can see if it is distributing the load as desired"
+    "We can predict using the `SeldonDeployment` multiple times, this way we can see how the load is split between the `main` and `canary` predictors"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 91,
+   "execution_count": 20,
    "id": "6c4256f7-a279-48b7-82e7-ca3a5a60104b",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "DEBUG:seldon_core.seldon_client:Configuration:{'gateway': 'istio', 'transport': 'rest', 'namespace': 'seldon-demo', 'deployment_name': 'sd-example-canary', 'payload_type': 'tensor', 'gateway_endpoint': '10.64.140.43', 'microservice_endpoint': 'localhost:5000', 'grpc_max_send_message_length': 4194304, 'grpc_max_receive_message_length': 4194304, 'channel_credentials': None, 'call_credentials': None, 'debug': False, 'client_return_type': 'dict', 'ssl': None}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from seldon_core.seldon_client import SeldonClient\n",
     "\n",
     "sc = SeldonClient(\n",
     "    gateway=\"istio\",\n",
-    "    deployment_name=seldon_deployment_name,\n",
+    "    deployment_name=seldon_deployment_canary_name,\n",
     "    namespace=model_name,\n",
     "    gateway_endpoint=gateway_ip\n",
     ")"
@@ -620,521 +618,25 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 92,
+   "execution_count": 21,
    "id": "639d8504-9d6d-4c7f-9cdf-aff43c2cb0b0",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05554955731239537]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.0870091499295114]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 157\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.052991143682868024]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08030132858376389]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06312795484024333]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08322240364505004]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.12544973129668835]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.12129177432039209]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07983221851710066]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 154\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.073658974426667]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06580302274253211]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08695038972523683]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06858469089618405]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07217343029641078]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07470544031875946]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 157\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.058333418343276704]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05152170715365609]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06121129361149572]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06857070672968726]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10774019502564221]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06761406436822569]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.09743201468539289]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.1260322252524635]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08285770846960563]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05720513302090965]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06433972382247694]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10026297834752762]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06632253798384825]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.11074646566263582]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05219818300484121]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05628205654827272]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08997712013218655]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08556230573956275]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06668995480396316]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06347389425108753]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07613014744330177]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07847743093627758]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06336165281563878]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07463382405638495]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05601599338233754]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05814908897704056]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08131847959049344]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08514375445885225]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.1211884926417159]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.1165568657525379]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.1159252415028424]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07166529668768763]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07103815006946987]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07532612193018186]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07020615822748993]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08194110933214269]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06960763670854465]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10027648973261799]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10104636795020713]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10942147525324357]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06718163856816584]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.09305362516760812]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 157\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.057274194663729454]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.12426070819309708]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.1026280133964406]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08368088833585935]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.11864869870265946]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.1112185201291976]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10483848024291785]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 157\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.055262039417025476]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10885385162473729]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08033365438942365]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07231858767684424]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07287685898568622]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10134426287153236]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.0699643733580762]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06134548029691366]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07813319633053682]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.11453192636066012]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05852696575071936]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 157\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.059411958186982916]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 157\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.061870262265794264]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.12794016477935458]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.1034049285384411]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.09062851527194803]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05882648098885694]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.1181650564247353]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06205659777824486]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 155\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.0534543510995789]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.05318001101872843]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07990267716883673]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.09432725499632359]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10417186490362211]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.12818773506490352]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06191218287079697]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.10381087351072414]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.09961087857645234]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06737044260209733]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.09603014194721878]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06652441482784867]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.06999814668729944]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.09677246172792608]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.08992512205290529]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.11925995809948013]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n",
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 156\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.07536681430678654]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n"
+      "Successfully completed 100 predictions\n"
      ]
     }
    ],
    "source": [
-    "for _ in range(100):\n",
+    "n = 100\n",
+    "for _ in range(n):\n",
     "    r = sc.predict(gateway=\"istio\", transport=\"rest\")\n",
-    "    assert r.success, \"Something went wrong - is the gateway set up correctly?\""
+    "    assert r.success, \"Something went wrong - is the gateway set up correctly?\"\n",
+    "else:\n",
+    "    print(f\"Successfully completed {n} predictions\")"
    ]
   },
   {
@@ -1147,46 +649,52 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 96,
+   "execution_count": 22,
    "id": "cdb54a37-4674-4add-9ab6-ffea214caf3a",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "jsonpath = \"'{.items[0].metadata.name}'\"\n",
-    "main_count = !kubectl logs $(kubectl get pod -lseldon-app=$seldon_deployment_name-main -o jsonpath=$jsonpath) classifier | grep \"root:predict\" | wc -l\n",
-    "main_count = main_count[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 97,
-   "id": "66ce5eee-5a6a-4d3b-99da-834b4258c91c",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "jsonpath = \"'{.items[0].metadata.name}'\"\n",
-    "canary_count = !kubectl logs $(kubectl get pod -lseldon-app=$seldon_deployment_name-canary -o jsonpath=$jsonpath) classifier | grep \"root:predict\" | wc -l\n",
-    "canary_count = canary_count[0]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 98,
-   "id": "0c369ff0-bd40-4268-8542-ecff41a0452e",
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Number of times main was hit: 67\n",
-      "Number of times canary was hit: 33\n"
+      "Number of times main was hit: 76\n"
      ]
     }
    ],
    "source": [
-    "print(f\"Number of times main was hit: {main_count}\")\n",
+    "jsonpath = \"'{.items[0].metadata.name}'\"\n",
+    "main_count = !kubectl logs $(kubectl get pod -lseldon-app=$seldon_deployment_canary_name-main -o jsonpath=$jsonpath) classifier | grep \"root:predict\" | wc -l\n",
+    "main_count = main_count[0]\n",
+    "print(f\"Number of times main was hit: {main_count}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "66ce5eee-5a6a-4d3b-99da-834b4258c91c",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of times canary was hit: 24\n"
+     ]
+    }
+   ],
+   "source": [
+    "jsonpath = \"'{.items[0].metadata.name}'\"\n",
+    "canary_count = !kubectl logs $(kubectl get pod -lseldon-app=$seldon_deployment_canary_name-canary -o jsonpath=$jsonpath) classifier | grep \"root:predict\" | wc -l\n",
+    "canary_count = canary_count[0]\n",
     "print(f\"Number of times canary was hit: {canary_count}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1b304f09-362e-466c-b122-57390e2582f7",
+   "metadata": {},
+   "source": [
+    "And we should see a ratio roughly equal to the 75:25 traffic split we defined above"
    ]
   },
   {
@@ -1194,7 +702,7 @@
    "id": "7cebe6fc-3020-42e6-b3bd-57e78b64f010",
    "metadata": {},
    "source": [
-    "# Access with Authentication"
+    "# Accessing Models Protected behind Dex"
    ]
   },
   {
@@ -1218,12 +726,14 @@
    "id": "01f3f23c-6949-469e-b60a-63ecd0e18de2",
    "metadata": {},
    "source": [
-    "By adding the `dex-auth` and `oidc-gatekeeper` charms and setting the credentials and `public-url` configurations, we can add authentication to our existing ingress gateway"
+    "By adding the `dex-auth` and `oidc-gatekeeper` charms and setting the credentials and `public-url` configurations, we can add authentication to our existing ingress gateway\n",
+    "\n",
+    "(note that this section uses information from [here](https://docs.seldon.io/projects/seldon-core/en/latest/examples/seldon_client.html))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 105,
+   "execution_count": 24,
    "id": "1a646a06-6cf0-46bc-8af4-c9abdc95b110",
    "metadata": {},
    "outputs": [],
@@ -1234,32 +744,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 100,
+   "execution_count": null,
    "id": "59b84e27-3720-4ffc-84b3-970cad2ab217",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Located charm \"dex-auth\" in charm-hub, revision 78\n",
-      "Deploying \"dex-auth\" from charm-hub charm \"dex-auth\", revision 78 in channel 2.28/stable\n",
-      "Located charm \"oidc-gatekeeper\" in charm-hub, revision 57\n",
-      "Deploying \"oidc-gatekeeper\" from charm-hub charm \"oidc-gatekeeper\", revision 57 in channel stable\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "!juju deploy dex-auth --trust --config static-username=$username --config static-password=$password --config public-url=$ingress_ip\n",
-    "!juju deploy oidc-gatekeeper --config public-url=$ingress_ip\n",
+    "!juju deploy dex-auth --trust --config static-username=$username --config static-password=$password --config public-url=http://$ingress_ip\n",
+    "!juju deploy oidc-gatekeeper --config public-url=http://$ingress_ip\n",
     "\n",
+    "!juju relate dex-auth istio-pilot\n",
     "!juju relate dex-auth oidc-gatekeeper\n",
-    "!juju relate dex-auth istio-pilot"
+    "\n",
+    "!juju relate oidc-gatekeeper:ingress istio-pilot:ingress\n",
+    "!juju relate oidc-gatekeeper:ingress-auth istio-pilot:ingress-auth"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 101,
+   "execution_count": 26,
    "id": "cc8b274f-9904-4aac-b34c-daa18b7a698f",
    "metadata": {},
    "outputs": [
@@ -1267,40 +769,12 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DEBUG:root:dex-auth/0 workload status is maintenance since 2022-02-25 22:20:46+00:00\n",
-      "DEBUG:root:dex-auth/0 juju agent status is executing since 2022-02-25 22:20:46+00:00\n",
-      "DEBUG:root:oidc-gatekeeper/0 juju agent status is allocating since 2022-02-25 22:20:34+00:00\n",
-      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:20:53+00:00\n",
-      "DEBUG:root:dex-auth/0 juju agent status is executing since 2022-02-25 22:20:46+00:00\n",
-      "DEBUG:root:oidc-gatekeeper/0 juju agent status is executing since 2022-02-25 22:20:54+00:00\n",
-      "DEBUG:root:dex-auth/0 workload status is waiting since 2022-02-25 22:20:57+00:00\n",
-      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:20:58+00:00\n",
-      "DEBUG:root:dex-auth/0 juju agent status is executing since 2022-02-25 22:20:58+00:00\n",
-      "DEBUG:root:istio-pilot/0 juju agent status is executing since 2022-02-25 22:20:57+00:00\n",
-      "DEBUG:root:oidc-gatekeeper/0 juju agent status is executing since 2022-02-25 22:20:56+00:00\n",
-      "DEBUG:root:istio-pilot/0 workload status is maintenance since 2022-02-25 22:21:02+00:00\n",
-      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:20:58+00:00\n",
-      "DEBUG:root:dex-auth/0 juju agent status is executing since 2022-02-25 22:21:02+00:00\n",
-      "DEBUG:root:istio-pilot/0 juju agent status is executing since 2022-02-25 22:21:00+00:00\n",
-      "DEBUG:root:oidc-gatekeeper/0 juju agent status is executing since 2022-02-25 22:21:00+00:00\n",
-      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:21:05+00:00\n",
-      "DEBUG:root:dex-auth/0 juju agent status is executing since 2022-02-25 22:21:06+00:00\n",
-      "DEBUG:root:istio-pilot/0 juju agent status is executing since 2022-02-25 22:21:06+00:00\n",
-      "DEBUG:root:oidc-gatekeeper/0 juju agent status is executing since 2022-02-25 22:21:04+00:00\n",
-      "DEBUG:root:dex-auth/0 workload status is maintenance since 2022-02-25 22:21:11+00:00\n",
-      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:21:05+00:00\n",
-      "DEBUG:root:dex-auth/0 juju agent status is executing since 2022-02-25 22:21:10+00:00\n",
-      "DEBUG:root:oidc-gatekeeper/0 juju agent status is executing since 2022-02-25 22:21:07+00:00\n",
-      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:21:15+00:00\n",
-      "DEBUG:root:dex-auth/0 juju agent status is executing since 2022-02-25 22:21:15+00:00\n",
-      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:21:15+00:00\n",
-      "DEBUG:root:dex-auth/0 juju agent status is executing since 2022-02-25 22:21:18+00:00\n",
-      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:21:15+00:00\n",
-      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:21:15+00:00\n",
-      "DEBUG:root:oidc-gatekeeper/0 workload status is waiting since 2022-02-25 22:21:15+00:00\n",
-      "^C\n",
-      "Traceback (most recent call last):\n",
-      "  File \"/snap/juju-wait/96/bin/juju-wait\", line 33, in <module>\n"
+      "INFO:root:All units idle since 2022-02-28 19:24:51.829943Z (dex-auth/6, istio-ingressgateway/2, istio-pilot/2, oidc-gatekeeper/1, seldon-controller-manager/1)\n",
+      "DEBUG:root:dex-auth is lead by dex-auth/6\n",
+      "DEBUG:root:istio-ingressgateway is lead by istio-ingressgateway/2\n",
+      "DEBUG:root:istio-pilot is lead by istio-pilot/2\n",
+      "DEBUG:root:oidc-gatekeeper is lead by oidc-gatekeeper/1\n",
+      "DEBUG:root:seldon-controller-manager is lead by seldon-controller-manager/1\n"
      ]
     }
    ],
@@ -1313,12 +787,14 @@
    "id": "72175420-43e1-4cbd-b056-5372d662dbdc",
    "metadata": {},
    "source": [
-    "To authenticate and obtain a authorization cookie, use the `kubeflow_login` helper.  For the url, you can use any valid url that has a VirtualService passing traffic through, such as the models we are serving."
+    "To authenticate and obtain a authorization cookie, we then can either:\n",
+    "* use the `authservice_cookie` from an authenticated browser session\n",
+    "* use the `kubeflow_login` helper below.  For the url passed to the helper, use any valid url that has a VirtualService passing traffic through (such as the models we are serving)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 103,
+   "execution_count": 27,
    "id": "ba561515-d24b-49e5-a844-78cd60817aae",
    "metadata": {},
    "outputs": [],
@@ -1409,100 +885,69 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 106,
+   "execution_count": 28,
    "id": "2d72289b-27cc-4570-a16f-795e39735b92",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"GET /seldon/seldon-demo/sd-example-canary/ HTTP/1.1\" 404 19\n"
-     ]
-    },
-    {
-     "ename": "ValueError",
-     "evalue": "Failed to connect to url site 'http://10.64.140.43/seldon/seldon-demo/sd-example-canary/'.  Got response 404, expected one of [200]",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
-      "\u001b[0;32m/tmp/ipykernel_536803/570625492.py\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0murl\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;34mf\"http://{gateway_ip}/seldon/{model_name}/{seldon_deployment_name}/\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mauthservice_cookie\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mkubeflow_login\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0murl\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0musername\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0musername\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpassword\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mpassword\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m/tmp/ipykernel_536803/1191261482.py\u001b[0m in \u001b[0;36mkubeflow_login\u001b[0;34m(url, username, password)\u001b[0m\n\u001b[1;32m     27\u001b[0m         \u001b[0mallow_redirects\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     28\u001b[0m     )\n\u001b[0;32m---> 29\u001b[0;31m     \u001b[0mvalidate_response_status_code\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mresponse\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m[\u001b[0m\u001b[0;36m200\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34mf\"Failed to connect to url site '{url}'.\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     30\u001b[0m     \u001b[0mdex_login_url\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0murl\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     31\u001b[0m     \u001b[0mlogging\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdebug\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf\"Redirected to dex_login_url of '{dex_login_url}'\"\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m/tmp/ipykernel_536803/1191261482.py\u001b[0m in \u001b[0;36mvalidate_response_status_code\u001b[0;34m(response, expected_codes, error_message)\u001b[0m\n\u001b[1;32m     77\u001b[0m         \u001b[0merror_message\u001b[0m \u001b[0;34m+=\u001b[0m \u001b[0;34m\"  \"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     78\u001b[0m     \u001b[0;32mif\u001b[0m \u001b[0mresponse\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstatus_code\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mexpected_codes\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 79\u001b[0;31m         raise ValueError(\n\u001b[0m\u001b[1;32m     80\u001b[0m             \u001b[0;34mf\"{error_message}\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     81\u001b[0m             \u001b[0;34mf\"Got response {response.status_code}, expected one of {expected_codes}\"\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mValueError\u001b[0m: Failed to connect to url site 'http://10.64.140.43/seldon/seldon-demo/sd-example-canary/'.  Got response 404, expected one of [200]"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "url = f\"http://{gateway_ip}/seldon/{model_name}/{seldon_deployment_name}/\"\n",
+    "url = f\"http://{gateway_ip}/seldon/{model_name}/{seldon_deployment_canary_name}/\"\n",
     "authservice_cookie = kubeflow_login(url, username=username, password=password)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "9bae5b18-00dc-4ed3-8dc5-6ba4fd8b58db",
+   "id": "fd07b1fb-6e93-4959-a341-a3e940985759",
    "metadata": {},
    "source": [
-    "And use the cookie in our seldon client"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 91,
-   "id": "4b42dbbc-6465-4ce5-ab6f-fc34739a5383",
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "DEBUG:seldon_core.seldon_client:Configuration:{'gateway': 'istio', 'transport': 'rest', 'namespace': 'seldon-demo', 'deployment_name': 'sd-example-canary', 'payload_type': 'tensor', 'gateway_endpoint': '10.64.140.43', 'microservice_endpoint': 'localhost:5000', 'grpc_max_send_message_length': 4194304, 'grpc_max_receive_message_length': 4194304, 'channel_credentials': None, 'call_credentials': None, 'debug': False, 'client_return_type': 'dict', 'ssl': None}\n"
-     ]
-    }
-   ],
-   "source": [
-    "from seldon_core.seldon_client import SeldonClient\n",
-    "\n",
-    "sc = SeldonClient(\n",
-    "    gateway=\"istio\",\n",
-    "    deployment_name=seldon_deployment_name,\n",
-    "    namespace=model_name,\n",
-    "    gateway_endpoint=gateway_ip\n",
-    ")"
+    "### Predictions using the Seldon Client"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "0f5546b8-060b-4cb2-b49f-45626da2765d",
+   "id": "6d40f24f-55a0-4c00-ac80-970184030e9c",
    "metadata": {},
    "source": [
-    "# Continue with this: \n",
-    "https://docs.seldon.io/projects/seldon-core/en/latest/examples/seldon_client.html"
+    "Based on [this](https://docs.seldon.io/projects/seldon-core/en/latest/examples/seldon_client.html) the client appears to only support an X-Auth token built-in, not credentials passed by cookie, so we can pass the cookie via a header."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 107,
-   "id": "74ba372b-b92b-4fc9-8c6f-82103acf9d8c",
+   "execution_count": 29,
+   "id": "637b1b54-d760-4425-b555-f4666d657e63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc = SeldonClient(\n",
+    "    gateway=\"istio\",\n",
+    "    deployment_name=seldon_deployment_canary_name,\n",
+    "    namespace=model_name,\n",
+    "    gateway_endpoint=gateway_ip,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "30593751-95ec-44f9-91a6-162ae5a048fe",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
+     "name": "stdout",
      "output_type": "stream",
      "text": [
-      "DEBUG:seldon_core.seldon_client:URL is http://10.64.140.43/seldon/seldon-demo/sd-example-canary/api/v1.0/predictions\n",
-      "DEBUG:urllib3.connectionpool:Starting new HTTP connection (1): 10.64.140.43:80\n",
-      "DEBUG:urllib3.connectionpool:http://10.64.140.43:80 \"POST /seldon/seldon-demo/sd-example-canary/api/v1.0/predictions HTTP/1.1\" 200 157\n",
-      "DEBUG:seldon_core.seldon_client:Raw response: {\"data\":{\"names\":[\"proba\"],\"tensor\":{\"shape\":[1,1],\"values\":[0.055356987829593515]}},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n",
-      "\n"
+      "Congratulations, prediction returned response:\n",
+      "{'data': {'names': ['proba'], 'tensor': {'shape': [1, 1], 'values': [0.08470067019190682]}}, 'meta': {'requestPath': {'classifier': 'seldonio/mock_classifier:1.7.0'}}}\n"
      ]
     }
    ],
    "source": [
-    "r = sc.predict(gateway=\"istio\", transport=\"rest\")\n",
-    "if r.success, r.response\n",
+    "r = sc.predict(\n",
+    "    gateway=\"istio\", \n",
+    "    transport=\"rest\", \n",
+    "    headers={\"Cookie\": 'authservice_session=MTY0NjA3MjI5MXxOd3dBTkRRMlZFeEhXVTFVTTFaVFMwTXpUVEphVlRKSVdUSlBXVFphU0VwSFZsQkpVRmRSU0VoU04wNUhOelJKTWsxS1YweElOVkU9fKtVtvdPavl_pIIENxnXbqB7ULan_5rzk1BWf8HEZx8j'},\n",
+    ")\n",
+    "\n",
+    "if r.success:\n",
     "    print(\"Congratulations, prediction returned response:\")\n",
     "    print(r.response)\n",
     "else:\n",
@@ -1510,12 +955,96 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "c664fe04-dfc6-4834-82b1-8d840d5a7fc6",
+   "metadata": {},
+   "source": [
+    "### Predictions using requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0e2ac1b6-74ad-46a4-9e63-ac3b07ba0490",
+   "metadata": {},
+   "source": [
+    "Using the cookie obtained above, predictions can also be made using packages such as `requests`:"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": null,
-   "id": "b37cc480-91a0-4039-92be-a207ef4fcecb",
+   "execution_count": 31,
+   "id": "26f9d3a7-541b-4b9e-9dbc-56d8ac66ca7e",
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "import requests\n",
+    "cookies = {\"authservice_session\": authservice_cookie}\n",
+    "prediction_endpoint = f\"http://{gateway_ip}/seldon/{model_name}/{seldon_deployment_canary_name}/api/v1.0/predictions\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "72a635ac-667c-4f29-b015-ee25e8819591",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "response = b'{\"data\":{\"names\":[\"proba\"],\"ndarray\":[[0.12823373759251927]]},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\\n'\n"
+     ]
+    }
+   ],
+   "source": [
+    "r = requests.post(\n",
+    "    url=prediction_endpoint,\n",
+    "    cookies=cookies,\n",
+    "    json={\"data\": {\"ndarray\": [[1]]}},\n",
+    ")\n",
+    "print(f\"response = {r.content}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "754a07bd-804d-4913-8792-4b9a8eed63e4",
+   "metadata": {},
+   "source": [
+    "### Predictions using Curl"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51adcbc9-e4a8-4eaa-8a23-b8ad3bcbac03",
+   "metadata": {},
+   "source": [
+    "We can also make predictions using curl:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "39c56be6-04c4-4b83-9c94-d6cca2b2de2d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\"data\":{\"names\":[\"proba\"],\"ndarray\":[[0.12823373759251927]]},\"meta\":{\"requestPath\":{\"classifier\":\"seldonio/mock_classifier:1.7.0\"}}}\n"
+     ]
+    }
+   ],
+   "source": [
+    "jsonpath = \"'{.items[0].spec.clusterIP}'\"\n",
+    "classifier_svc_ip=!kubectl get svc -l seldon-deployment-id=$seldon_deployment_name,seldon.io/model=true -o jsonpath=$jsonpath\n",
+    "classifier_svc_ip = classifier_svc_ip[0]\n",
+    "content_type = \"'Content-Type: application/json'\"\n",
+    "authservice_cookie_curl = f\"'Cookie: authservice_session={authservice_cookie}'\"\n",
+    "data = '\\'{\"data\": { \"ndarray\": [[1]]}}\\''\n",
+    "\n",
+    "!curl $gateway_ip/seldon/$model_name/$seldon_deployment_name/api/v1.0/predictions -X POST -H $content_type -H $authservice_cookie_curl -d $data"
+   ]
   }
  ],
  "metadata": {

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -11,8 +11,6 @@ resources:
     auto-fetch: true
     upstream-source: 'docker.io/seldonio/seldon-core-operator:1.6.0'
 requires:
-  istio:
-    interface: service-mesh
   ambassador:
     interface: service-mesh
   keda:

--- a/src/charm.py
+++ b/src/charm.py
@@ -53,6 +53,12 @@ class Operator(CharmBase):
         env = Environment(
             loader=FileSystemLoader("src/templates/"),
         )
+
+        if config["istio-gateway"] != "":
+            istio_enabled = "true"
+        else:
+            istio_enabled = "false"
+
         envs = {
             "AMBASSADOR_ENABLED": str(bool(self.model.relations["ambassador"])).lower(),
             "AMBASSADOR_SINGLE_NAMESPACE": str(
@@ -104,7 +110,7 @@ class Operator(CharmBase):
                 "executor-server-metrics-port-name"
             ],
             "EXECUTOR_SERVER_PORT": config["executor-server-port"],
-            "ISTIO_ENABLED": str(bool(self.model.relations["istio"])).lower(),
+            "ISTIO_ENABLED": istio_enabled,
             "ISTIO_GATEWAY": config["istio-gateway"],
             "ISTIO_TLS_MODE": config["istio-tls-mode"],
             "KEDA_ENABLED": str(bool(self.model.relations["keda"])).lower(),
@@ -132,7 +138,6 @@ class Operator(CharmBase):
             "USE_EXECUTOR": str(config["use-executor"]).lower(),
             "WATCH_NAMESPACE": config["watch-namespace"],
         }
-
         self.model.unit.status = MaintenanceStatus("Setting pod spec")
         self.model.pod.set_spec(
             {


### PR DESCRIPTION
Closes #18 

This fixes the integration with Istio, which previously needed a deprecated relation with an Istio charm.  Also added are several examples of using the SeldonDeployments with and without authentication

# Testing Instructions

Use the recipe prescribed in `/examples/ingress_canary_and_auth.ipynb`, which should demo all new features