### PR TITLE
ci: microk8s version bump 1.21->1.22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
       uses: charmed-kubernetes/actions-operator@main
       with:
         provider: microk8s
-        channel: 1.21/stable
+        channel: 1.22/stable
 
     - name: Run integration tests
       run: tox -vve integration -- --model testing


### PR DESCRIPTION
Change to be able to test training-operator 1.5.0 in microk8s 1.22

Merge after #30 