### PR TITLE
Observe leader-elected

### DIFF
--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -1,6 +1,6 @@
 import pytest
 import json
-from ops.model import ActiveStatus, BlockedStatus
+from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Harness
 
 from charm import Operator
@@ -12,8 +12,8 @@ def harness():
 
 
 def test_not_leader(harness):
-    harness.begin()
-    assert harness.charm.model.unit.status == ActiveStatus("")
+    harness.begin_with_initial_hooks()
+    assert harness.charm.model.unit.status == WaitingStatus("Waiting for leadership")
 
 
 def test_missing_image(harness):


### PR DESCRIPTION
This PR standardizes handling the status when the unit is not leader and adds `leader-elected` to observed events.