### PR TITLE
refactor: remove cert-manager annotation

### DIFF
--- a/src/templates/validate.yaml
+++ b/src/templates/validate.yaml
@@ -2,8 +2,6 @@
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
-  annotations:
-    cert-manager.io/inject-ca-from: kubeflow/seldon-serving-cert
   labels:
     app: seldon
     app.kubernetes.io/instance: 'seldon-core'


### PR DESCRIPTION
We do not use cert-manager, thus this annotation is not needed.