### PR TITLE
Bug: Add missing Istio relation to Seldon (discard this PR)

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -84,7 +84,7 @@ jobs:
           echo "::set-output name=tag_prefix::$tag_prefix"
 
       - name: Upload charm to charmhub
-        uses: canonical/charming-actions/upload-charm@2.1.0
+        uses: canonical/charming-actions/upload-charm@2.1.1
         with:
           credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/charms/istio_pilot/v0/istio_gateway_info.py
+++ b/lib/charms/istio_pilot/v0/istio_gateway_info.py
@@ -1,0 +1,125 @@
+"""Library for sharing istio gateway information
+
+This library wraps the relation endpoints using the `istio-gateway-name`
+interface. It provides a Python API for both requesting and providing 
+gateway information.
+
+## Getting Started
+
+### Fetch library with charmcraft
+You can fetch the library using the following commands with charmcraft.
+```shell
+cd some-charm
+charmcraft fetch-lib charms.istio_pilot.v0.istio_gateway_info
+```
+### Add relation to metadata.yaml
+```yaml
+requires:
+    gateway-info:
+        interface: istio_gateway_info
+        limit: 1
+```
+
+### Initialise the library in charm.py
+```python
+from charms.istio_pilot.v0.istio_gateway_info import GatewayProvider, GatewayRelationError
+
+Class SomeCharm(CharmBase):
+    def __init__(self, *args):
+        self.gateway = GatewayProvider(self)
+        self.framework.observe(self.on.some_event_emitted, self.some_event_function)
+
+    def some_event_function():
+        # use the getter function wherever the info is needed
+        try:
+            gateway_data = self.gateway_relation.get_relation_data()
+            except GatewayRelationError as error:
+            ...
+```
+"""
+
+import logging
+from ops.framework import Object
+from ops.model import Application
+
+# The unique Charmhub library identifier, never change it
+LIBID = "354103422e7a43e2870e4203fbb5a649"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+
+RELATION_NAME = "gateway-info"
+INTERFACE_NAME = "istio-gateway-info"
+
+logger = logging.getLogger(__name__)
+
+
+class GatewayRelationError(Exception):
+    pass
+
+
+class GatewayRelationMissingError(GatewayRelationError):
+    def __init__(self):
+        self.message = "Missing gateway-info relation with istio-pilot"
+        super().__init__(self.message)
+
+
+class GatewayRelationTooManyError(GatewayRelationError):
+    def __init__(self):
+        self.message = "Too many istio-gateway-info relations"
+        super().__init__(self.message)
+
+
+class GatewayRelationDataMissingError(GatewayRelationError):
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+
+class GatewayRequirer(Object):
+    def __init__(self, charm, relation_name: str = RELATION_NAME):
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+
+    def get_relation_data(self):
+        if not self.model.unit.is_leader():
+            return
+        gateway = self.model.relations[self.relation_name]
+        if len(gateway) == 0:
+            raise GatewayRelationMissingError()
+        if len(gateway) > 1:
+            raise GatewayRelationTooManyError()
+
+        remote_app = [
+            app
+            for app in gateway[0].data.keys()
+            if isinstance(app, Application) and not app._is_our_app
+        ][0]
+
+        data = gateway[0].data[remote_app]
+
+        if not "gateway_name" in data:
+            logger.error(
+                "Missing gateway name in gateway-info relation data. Waiting for gateway creation in istio-pilot"
+            )
+            raise GatewayRelationDataMissingError(
+                "Missing gateway name in gateway-info relation data. Waiting for gateway creation in istio-pilot"
+            )
+
+        if not "gateway_namespace" in data:
+            logger.error("Missing gateway namespace in gateway-info relation data")
+            raise GatewayRelationDataMissingError(
+                "Missing gateway namespace in gateway-info relation data"
+            )
+
+        return {
+            "gateway_name": data["gateway_name"],
+            "gateway_namespace": data["gateway_namespace"],
+        }
+

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -13,12 +13,13 @@ resources:
     auto-fetch: true
     upstream-source: 'docker.io/seldonio/seldon-core-operator:1.14.0'
 requires:
-  istio:
-    interface: service-mesh
   ambassador:
     interface: service-mesh
   keda:
     interface: autoscaling
+  gateway-info:
+    interface: istio-gateway-info
+    limit: 1
 provides:
   metrics-endpoint:
     interface: prometheus_scrape


### PR DESCRIPTION
**PR: Add Istio Pilto relation to Seldon Core Operator**
Work tracked in
https://github.com/canonical/seldon-core-operator/issues/18
and
https://github.com/canonical/seldon-core-operator/issues/20

**Summary of changes:**
- Implemented istio relation handling in charm's code.
- Added unit and integration tests.
- Bumped version in .github/workflow/
- Added istio gateway lib.

**Outcomes**
Seldon should be deployed with Istio in the same model and relation should be successful.

**Testing**
To verify proper relation handling, deploy Istio Pilot and Istio Gateway with relation. Deploy Seldon Core Operator. Then relate Seldon Core Operator with Istio Pilot. The corresponig relation should be established,

```
juju bootstrap microk8s test
juju add-model seldon-istio-test
juju deploy istio-pilot --trust --channel latest/edge --config default-gateway=my-gateway
juju deploy istio-gateway istio-ingressgateway --trust --channel latest/edge --config kind=ingress
juju relate istio-pilot istio-ingressgateway
charmcraft pack
juju deploy ./seldon-core_ubuntu-20.04-amd64.charm seldon-controller-manager --trust --resource oci-image="docker.io/seldonio/seldon-core-operator:1.14.0"
juju relate seldon-controller-manager istio-pilot
juju status --relations
Relation provider         Requirer                                Interface           Type
istio-pilot:gateway-info  seldon-controller-manager:gateway-info  istio-gateway-info  regular  
istio-pilot:istio-pilot   istio-ingressgateway:istio-pilot        k8s-service         regular  
```

