### PR TITLE
Don't scan requirements*.txt for renovate runs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,11 +7,19 @@
     },
     "pip-compile": {
         "fileMatch": [
-            "(^|/)requirements.*\\.in$"
+            "requirements.in",
+            "requirements-fmt.in",
+            "requirements-lint.in",
+            "requirements-unit.in",
+            "requirements-integration.in"
         ],
         "lockFileMaintenance": {
+            "enabled": true,
             "schedule": null
         }
+    },
+    "pip_requirements": {
+        "enabled": false
     },
     "automergeType": "branch",
     "packageRules": [


### PR DESCRIPTION
We want only to scan pip compile requirements*.in files during renovate run not requirements*.txt. This PR also tries to fix chicken and egg problem during pip compile by specifying explicit order of scans.