### PR TITLE
Fix endpoint discovery

### DIFF
--- a/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
+++ b/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
@@ -46,7 +46,7 @@ import signal
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, Iterable
+from typing import Dict, Iterable, cast
 
 from lightkube import Client
 from lightkube.resources.core_v1 import Pod
@@ -164,15 +164,15 @@ class MetricsEndpointObserver(Object):
             env=new_env,
         ).pid
 
-        self._observer_pid = pid
+        self._observer_pid = pid  # type: ignore
 
     def stop_observer(self):
         """Stop the running observer process if we have previously started it."""
-        if not self._observer_pid:
+        if not self._observer_pid:  # type: ignore
             return
 
         try:
-            os.kill(self._observer_pid, signal.SIGINT)
+            os.kill(self._observer_pid, signal.SIGINT)  # type: ignore
             msg = "Stopped running metrics endpoint observer process with PID {}"
             logging.info(msg.format(self._observer_pid))
         except OSError:

--- a/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
+++ b/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
@@ -46,7 +46,7 @@ import signal
 import subprocess
 import sys
 from pathlib import Path
-from typing import Dict, Iterable, cast
+from typing import Dict, Iterable
 
 from lightkube import Client
 from lightkube.resources.core_v1 import Pod

--- a/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
+++ b/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
@@ -1,0 +1,234 @@
+# Copyright 2022 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""# MetricsEndpointDiscovery Library.
+
+This library provides functionality for discovering metrics endpoints exposed
+by applications deployed to a Kubernetes cluster.
+
+It comprises:
+- A custom event and event source for handling metrics endpoint changes.
+- Logic to observe cluster events and emit the events as appropriate.
+
+## Using the Library
+
+### Handling Events
+
+To ensure that your charm can react to changing metrics endpoint events,
+use the CharmEvents extension.
+```python
+import json
+
+from charms.observability_libs.v0.metrics_endpoint_discovery import
+    MetricsEndpointCharmEvents,
+    MetricsEndpointObserver
+)
+
+class MyCharm(CharmBase):
+
+    on = MetricsEndpointChangeCharmEvents()
+
+    def __init__(self, *args):
+        super().__init__(*args)
+
+        self._observer = MetricsEndpointObserver(self, {"app.kubernetes.io/name": ["grafana-k8s"]})
+        self.framework.observe(self.on.metrics_endpoint_change, self._on_endpoints_change)
+
+    def _on_endpoints_change(self, event):
+        self.unit.status = ActiveStatus(json.dumps(event.discovered))
+```
+"""
+
+import json
+import logging
+import os
+import signal
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, Iterable
+
+from lightkube import Client
+from lightkube.resources.core_v1 import Pod
+from ops.charm import CharmBase, CharmEvents
+from ops.framework import EventBase, EventSource, Object
+
+logger = logging.getLogger(__name__)
+
+# The unique Charmhub library identifier, never change it
+LIBID = "a141d5620152466781ed83aafb948d03"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 2
+
+# File path where metrics endpoint change data is written for exchange
+# between the discovery process and the materialised event.
+PAYLOAD_FILE_PATH = "/tmp/metrics-endpoint-payload.json"
+
+# File path for the spawned discovery process to write logs.
+LOG_FILE_PATH = "/var/log/discovery.log"
+
+
+class MetricsEndpointChangeEvent(EventBase):
+    """A custom event for metrics endpoint changes."""
+
+    def __init__(self, handle):
+        super().__init__(handle)
+
+        with open(PAYLOAD_FILE_PATH, "r") as f:
+            self._discovered = json.loads(f.read())
+
+    def snapshot(self):
+        """Save the event payload data."""
+        return {"payload": self._discovered}
+
+    def restore(self, snapshot):
+        """Restore the event payload data."""
+        self._discovered = {}
+
+        if snapshot:
+            self._discovered = snapshot["payload"]
+
+    @property
+    def discovered(self):
+        """Return the payload of detected endpoint changes for this event."""
+        return self._discovered
+
+
+class MetricsEndpointChangeCharmEvents(CharmEvents):
+    """A CharmEvents extension for metrics endpoint changes.
+
+    Includes :class:`MetricsEndpointChangeEvent` in those that can be handled.
+    """
+
+    metrics_endpoint_change = EventSource(MetricsEndpointChangeEvent)
+
+
+class MetricsEndpointObserver(Object):
+    """Observes changing metrics endpoints in the cluster.
+
+    Observed endpoint changes cause :class"`MetricsEndpointChangeEvent` to be emitted.
+    """
+
+    def __init__(self, charm: CharmBase, labels: Dict[str, Iterable]):
+        """Constructor for MetricsEndpointObserver.
+
+        Args:
+            charm: the charm that is instantiating the library.
+            labels: dictionary of label/value to be observed for changing metrics endpoints.
+        """
+        super().__init__(charm, "metrics-endpoint-observer")
+
+        self._charm = charm
+        self._observer_pid = 0
+
+        self._labels = labels
+        self.start_observer()
+
+    def start_observer(self):
+        """Start the metrics endpoint observer running in a new process."""
+        self.stop_observer()
+
+        # We need to trick Juju into thinking that we are not running
+        # in a hook context, as Juju will disallow use of juju-run.
+        new_env = os.environ.copy()
+        if "JUJU_CONTEXT_ID" in new_env:
+            new_env.pop("JUJU_CONTEXT_ID")
+
+        tool_prefix = f"/var/lib/juju/tools/{self.unit_tag}"
+        if juju_run_path := Path(tool_prefix, "juju-run").exists():
+            tool_path = juju_run_path
+        else:
+            tool_path = Path("/usr/bin/juju-exec")
+
+        pid = subprocess.Popen(
+            [
+                "/usr/bin/python3",
+                "lib/charms/observability_libs/v{}/metrics_endpoint_discovery.py".format(LIBAPI),
+                json.dumps(self._labels),
+                str(tool_path),
+                self._charm.unit.name,
+                self._charm.charm_dir,
+            ],
+            stdout=open(LOG_FILE_PATH, "a"),
+            stderr=subprocess.STDOUT,
+            start_new_session=True,
+            env=new_env,
+        ).pid
+
+        self._observer_pid = pid
+
+    def stop_observer(self):
+        """Stop the running observer process if we have previously started it."""
+        if not self._observer_pid:
+            return
+
+        try:
+            os.kill(self._observer_pid, signal.SIGINT)
+            msg = "Stopped running metrics endpoint observer process with PID {}"
+            logging.info(msg.format(self._observer_pid))
+        except OSError:
+            pass
+
+    @property
+    def unit_tag(self):
+        """Juju-style tag identifying the unit being run by this charm."""
+        unit_num = self._charm.unit.name.split("/")[-1]
+        return "unit-{}-{}".format(self._charm.app.name, unit_num)
+
+
+def write_payload(payload):
+    """Write the input event data to event payload file."""
+    with open(PAYLOAD_FILE_PATH, "w") as f:
+        f.write(json.dumps(payload))
+
+
+def dispatch(run_cmd, unit, charm_dir):
+    """Use the input juju-run command to dispatch a :class:`MetricsEndpointChangeEvent`."""
+    dispatch_sub_cmd = "JUJU_DISPATCH_PATH=hooks/metrics_endpoint_change {}/dispatch"
+    subprocess.run([run_cmd, "-u", unit, dispatch_sub_cmd.format(charm_dir)])
+
+
+def main():
+    """Main watch and dispatch loop.
+
+    Watch the input k8s service names. When changes are detected, write the
+    observed data to the payload file, and dispatch the change event.
+    """
+    labels, run_cmd, unit, charm_dir = sys.argv[1:]
+
+    client = Client()
+    labels = json.loads(labels)
+
+    for change, entity in client.watch(Pod, namespace="*", labels=labels):
+        if Path(PAYLOAD_FILE_PATH).exists():
+            dispatch(run_cmd, unit, charm_dir)
+            Path(PAYLOAD_FILE_PATH).unlink()
+        meta = entity.metadata
+        metrics_path = ""
+        if entity.metadata.annotations.get("prometheus.io/path", ""):
+            metrics_path = entity.metadata.annotations.get("prometheus.io/path", "")
+
+        target_ports = []
+        for c in filter(lambda c: c.ports is not None, entity.spec.containers):
+            for p in filter(lambda p: p.name == "metrics", c.ports):
+                target_ports.append("*:{}".format(p.containerPort))
+
+        payload = {
+            "change": change,
+            "namespace": meta.namespace,
+            "name": meta.name,
+            "path": metrics_path,
+            "targets": target_ports or ["*:80"],
+        }
+
+        write_payload(payload)
+        dispatch(run_cmd, unit, charm_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
+++ b/lib/charms/observability_libs/v0/metrics_endpoint_discovery.py
@@ -63,7 +63,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 # File path where metrics endpoint change data is written for exchange
 # between the discovery process and the materialised event.
@@ -140,8 +140,8 @@ class MetricsEndpointObserver(Object):
             new_env.pop("JUJU_CONTEXT_ID")
 
         tool_prefix = f"/var/lib/juju/tools/{self.unit_tag}"
-        if juju_run_path := Path(tool_prefix, "juju-run").exists():
-            tool_path = juju_run_path
+        if Path(tool_prefix, "juju-run").exists():
+            tool_path = Path(tool_prefix, "juju-run")
         else:
             tool_path = Path("/usr/bin/juju-exec")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -431,9 +431,11 @@ class SeldonCoreOperator(CharmBase):
         return ret_certs
 
     def _metrics_endpoint_change(self, event):
-        self._stored.targets[
-            f"{event.discovered['namespace']}-{event.discovered['name']}"
-        ] = event.discovered["targets"]
+        k = f"{event.discovered['namespace']}-{event.discovered['name']}"
+        if event.discovered["change"] == "DELETED" and self._stored.targets.get(k, ""):
+            del self._stored.targets[k]
+        else:
+            self._stored.targets[k] = event.discovered["targets"]
         self.prometheus_provider.set_scrape_job_spec()
 
     def _get_istio_gateway(self):

--- a/src/charm.py
+++ b/src/charm.py
@@ -464,6 +464,7 @@ class SeldonCoreOperator(CharmBase):
         self.model.unit.status = ActiveStatus()
 
     def return_list_of_running_models(self):
+        """Return the models and targets for endpoint discovery."""
         return [{"running-models": [{"targets": [p for p in self._stored.targets.values()]}]}]
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -9,13 +9,17 @@ import logging
 import tempfile
 from base64 import b64encode
 from pathlib import Path
-from subprocess import check_call
+from subprocess import DEVNULL, check_call
 
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
 from charmed_kubeflow_chisme.kubernetes import KubernetesResourceHandler
 from charmed_kubeflow_chisme.lightkube.batch import delete_many
 from charms.grafana_k8s.v0.grafana_dashboard import GrafanaDashboardProvider
 from charms.istio_pilot.v0.istio_gateway_info import GatewayRelationError, GatewayRequirer
+from charms.observability_libs.v0.metrics_endpoint_discovery import (
+    MetricsEndpointChangeCharmEvents,
+    MetricsEndpointObserver,
+)
 from charms.observability_libs.v1.kubernetes_service_patch import KubernetesServicePatch
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from lightkube import ApiError
@@ -46,6 +50,7 @@ class SeldonCoreOperator(CharmBase):
     """A Juju Charm for Seldon Core Operator."""
 
     _stored = StoredState()
+    on = MetricsEndpointChangeCharmEvents()
 
     def __init__(self, *args):
         """Initialize charm and setup the container."""
@@ -66,7 +71,7 @@ class SeldonCoreOperator(CharmBase):
         self._container = self.unit.get_container(self._container_name)
 
         # generate certs
-        self._stored.set_default(**self._gen_certs())
+        self._stored.set_default(**self._gen_certs(), targets={})
 
         # setup context to be used for updating K8S resources
         self._context = {
@@ -110,12 +115,21 @@ class SeldonCoreOperator(CharmBase):
                     "static_configs": [{"targets": ["*:{}".format(self.config["metrics-port"])]}],
                 }
             ],
+            lookaside_jobs_callable=self.return_list_of_running_models,
         )
 
         # Dashboard related config (Grafana)
         self.dashboard_provider = GrafanaDashboardProvider(
             charm=self,
             relation_name="grafana-dashboard",
+        )
+
+        self.metrics_server_observer = MetricsEndpointObserver(
+            self, {"seldon-deployment-id": None}
+        )
+        self.framework.observe(
+            self.on.metrics_endpoint_change,
+            self._metrics_endpoint_change,
         )
 
     @property
@@ -343,7 +357,8 @@ class SeldonCoreOperator(CharmBase):
             # execute OpenSSL commands
             check_call(["openssl", "genrsa", "-out", tmp_dir + "/seldon-cert-gen-ca.key", "2048"])
             check_call(
-                ["openssl", "genrsa", "-out", tmp_dir + "/seldon-cert-gen-server.key", "2048"]
+                ["openssl", "genrsa", "-out", tmp_dir + "/seldon-cert-gen-server.key", "2048"],
+                stdout=DEVNULL,
             )
             check_call(
                 [
@@ -361,7 +376,8 @@ class SeldonCoreOperator(CharmBase):
                     "/CN=127.0.0.1",
                     "-out",
                     tmp_dir + "/seldon-cert-gen-ca.crt",
-                ]
+                ],
+                stdout=DEVNULL,
             )
             check_call(
                 [
@@ -375,7 +391,8 @@ class SeldonCoreOperator(CharmBase):
                     tmp_dir + "/seldon-cert-gen-server.csr",
                     "-config",
                     tmp_dir + "/seldon-cert-gen-ssl.conf",
-                ]
+                ],
+                stdout=DEVNULL,
             )
             check_call(
                 [
@@ -398,7 +415,8 @@ class SeldonCoreOperator(CharmBase):
                     "v3_ext",
                     "-extfile",
                     tmp_dir + "/seldon-cert-gen-ssl.conf",
-                ]
+                ],
+                stdout=DEVNULL,
             )
 
             ret_certs = {
@@ -411,6 +429,12 @@ class SeldonCoreOperator(CharmBase):
             check_call(["rm", "-f", tmp_dir + "/seldon-cert-gen-*"])
 
         return ret_certs
+
+    def _metrics_endpoint_change(self, event):
+        self._stored.targets[
+            f"{event.discovered['namespace']}-{event.discovered['name']}"
+        ] = event.discovered["targets"]
+        self.prometheus_provider.set_scrape_job_spec()
 
     def _get_istio_gateway(self):
         """Parse 'gateway' relation and return Istio gateway definition in appropriate format."""
@@ -436,6 +460,9 @@ class SeldonCoreOperator(CharmBase):
             return
 
         self.model.unit.status = ActiveStatus()
+
+    def return_list_of_running_models(self):
+        return [{"running-models": [{"targets": [p for p in self._stored.targets.values()]}]}]
 
 
 #

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -33,6 +33,10 @@ class TestCharm:
     @patch("charm.SeldonCoreOperator.k8s_resource_handler")
     @patch("charm.SeldonCoreOperator.configmap_resource_handler")
     @patch("charm.SeldonCoreOperator.crd_resource_handler")
+    @patch(
+        "charms.observability_libs.v0.metrics_endpoint_discovery.MetricsEndpointObserver.start_observer",
+        lambda x: True,
+    )
     def test_not_leader(
         self,
         _: MagicMock,  # k8s_resource_handler
@@ -49,6 +53,10 @@ class TestCharm:
     @patch("charm.SeldonCoreOperator.k8s_resource_handler")
     @patch("charm.SeldonCoreOperator.configmap_resource_handler")
     @patch("charm.SeldonCoreOperator.crd_resource_handler")
+    @patch(
+        "charms.observability_libs.v0.metrics_endpoint_discovery.MetricsEndpointObserver.start_observer",
+        lambda x: True,
+    )
     def test_no_relation(
         self,
         _: MagicMock,  # k8s_resource_handler
@@ -72,6 +80,10 @@ class TestCharm:
         assert harness.charm.model.unit.status == ActiveStatus("")
 
     @patch("charm.KubernetesServicePatch", lambda x, y, service_name: None)
+    @patch(
+        "charms.observability_libs.v0.metrics_endpoint_discovery.MetricsEndpointObserver.start_observer",
+        lambda x: True,
+    )
     def test_prometheus_data_set(self, harness: Harness, mocker):
         """Test Prometheus data setting."""
         harness.set_leader(True)
@@ -140,6 +152,10 @@ class TestCharm:
     @patch("charm.SeldonCoreOperator.k8s_resource_handler")
     @patch("charm.SeldonCoreOperator.configmap_resource_handler")
     @patch("charm.SeldonCoreOperator.crd_resource_handler")
+    @patch(
+        "charms.observability_libs.v0.metrics_endpoint_discovery.MetricsEndpointObserver.start_observer",
+        lambda x: True,
+    )
     def test_pebble_layer(
         self,
         _: MagicMock,  # k8s_resource_handler
@@ -170,6 +186,10 @@ class TestCharm:
     @patch("charm.SeldonCoreOperator.k8s_resource_handler")
     @patch("charm.SeldonCoreOperator.configmap_resource_handler")
     @patch("charm.SeldonCoreOperator.crd_resource_handler")
+    @patch(
+        "charms.observability_libs.v0.metrics_endpoint_discovery.MetricsEndpointObserver.start_observer",
+        lambda x: True,
+    )
     def test_deploy_k8s_resources_success(
         self,
         k8s_resource_handler: MagicMock,
@@ -186,6 +206,10 @@ class TestCharm:
         assert isinstance(harness.charm.model.unit.status, MaintenanceStatus)
 
     @patch("charm.KubernetesServicePatch", lambda x, y, service_name: None)
+    @patch(
+        "charms.observability_libs.v0.metrics_endpoint_discovery.MetricsEndpointObserver.start_observer",
+        lambda x: True,
+    )
     def test_get_certs(self, harness: Harness):
         """Test certs generation."""
         harness.begin()
@@ -201,6 +225,10 @@ class TestCharm:
     @patch("charm.SeldonCoreOperator.k8s_resource_handler")
     @patch("charm.SeldonCoreOperator.configmap_resource_handler")
     @patch("charm.SeldonCoreOperator.crd_resource_handler")
+    @patch(
+        "charms.observability_libs.v0.metrics_endpoint_discovery.MetricsEndpointObserver.start_observer",
+        lambda x: True,
+    )
     def test_istio_relation(
         self,
         _: MagicMock,  # k8s_resource_handler

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ allowlist_externals =
     find
     pip-compile
     xargs
-commands = 
+commands =
 ; uses 'bash -c' because piping didn't work in regular tox commands
   pip-compile requirements.in
   pip-compile requirements-fmt.in
@@ -57,7 +57,7 @@ commands =
       --skip {toxinidir}/./.mypy_cache \
       --skip {toxinidir}/./icon.svg --skip *.json.tmpl
     # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
+    pflake8 {[vars]src_path}
     isort --check-only --diff {[vars]all_path}
     black --check --diff {[vars]all_path}
 deps =


### PR DESCRIPTION
The original implementation of endpoint discovery had drifted (on Juju2 and Juju3), and the required observer was not started.

Correct the library, and some error handling for data in the charm itself.