### PR TITLE
fix: remove BlockedStatus statements in charm code

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -297,7 +297,7 @@ class SeldonCoreOperator(CharmBase):
     def _upload_certs_to_container(self):
         """Upload generated certs to container."""
         try:
-           self._check_container_connection(self.container)
+            self._check_container_connection(self.container)
         except ErrorWithStatus as error:
             self.model.unit = error.status
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -296,7 +296,11 @@ class SeldonCoreOperator(CharmBase):
 
     def _upload_certs_to_container(self):
         """Upload generated certs to container."""
-        self._check_container_connection(self.container)
+        try:
+           self._check_container_connection(self.container)
+        except ErrorWithStatus as error:
+            self.model.unit = error.status
+            return
 
         self.container.push(CONTAINER_CERTS_DEST + "tls.key", self._stored.key, make_dirs=True)
         self.container.push(CONTAINER_CERTS_DEST + "tls.crt", self._stored.cert, make_dirs=True)

--- a/src/charm.py
+++ b/src/charm.py
@@ -324,7 +324,12 @@ class SeldonCoreOperator(CharmBase):
 
     def _on_pebble_ready(self, event):
         """Configure started container."""
-        self._check_container_connection(self.container)
+        # TODO: extract try/except to _check_container_connection()
+        try:
+            self._check_container_connection(self.container)
+        except ErrorWithStatus as error:
+            self.model.unit = error.status
+            return
 
         # container is ready
         # upload certs to container

--- a/src/charm.py
+++ b/src/charm.py
@@ -279,8 +279,8 @@ class SeldonCoreOperator(CharmBase):
             try:
                 self.logger.info("Pebble plan updated with new configuration, replaning")
                 self.container.replan()
-            except ChangeError as err:
-                raise ErrorWithStatus(f"Failed to replan with error: {str(err)}", BlockedStatus)
+            except ChangeError as e:
+                raise ChangeError("Failed to replan") from e
 
     def _upload_certs_to_container(self):
         """Upload generated certs to container."""
@@ -298,8 +298,8 @@ class SeldonCoreOperator(CharmBase):
             self.k8s_resource_handler.apply()
             self.crd_resource_handler.apply()
             self.configmap_resource_handler.apply()
-        except ApiError:
-            raise ErrorWithStatus("K8S resources creation failed", BlockedStatus)
+        except ApiError as e:
+            raise ApiError("Failed to create K8S resources") from e
         self.model.unit.status = MaintenanceStatus("K8S resources created")
 
     def _on_install(self, _):


### PR DESCRIPTION
This PR introduces:

* fix: remove BlockedStatus statements in charm code
    
    A BlockedStatus mean a human has to manually intervene to ublock
    the unit and let it proceed. There were some conditions where no
    external intervention could ublock the unit. Adding appropriate
    logging and exceptions to catch errors and set status correctly.
    
    Fixes canonical/bundle-kubeflow#549

* refactor: add method for checking if conection to container can be stablished

Note the CI is failing because of dependencies, #117 fixes those issues. This PR should be merged after that other one.