### PR TITLE
[backport] reuse ci (#114)

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -4,24 +4,16 @@ name: CI
 on:
   workflow_call:
     secrets:
-      charmcraft-credentials:
+      CHARMCRAFT_CREDENTIALS:
         required: true
 
 jobs:
-
   lib-check:
     name: Check libraries
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - name: Check libs
-        uses: canonical/charming-actions/check-libraries@2.1.1
-        with:
-          credentials: "${{ secrets.charmcraft-credentials }}"
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
+    uses: canonical/charmed-kubeflow-workflows/.github/workflows/_quality-checks.yaml@main
+    secrets: inherit
+    with:
+        charm-path: "."
 
   lint:
     name: Lint Check

--- a/.github/workflows/on_pull_request.yaml
+++ b/.github/workflows/on_pull_request.yaml
@@ -12,12 +12,11 @@ jobs:
   tests:
     name: Run Tests
     uses: ./.github/workflows/integrate.yaml
-    secrets:
-      charmcraft-credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+    secrets: inherit
 
   # publish runs in parallel with tests, as we always publish in this situation
   publish-charm:
     name: Publish Charm
     uses: ./.github/workflows/publish.yaml
-    secrets:
-      CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+    secrets: inherit
+

--- a/.github/workflows/on_push.yaml
+++ b/.github/workflows/on_push.yaml
@@ -3,28 +3,26 @@ name: On Push
 # On push to a "special" branch, we:
 # * always publish to charmhub at latest/edge/branchname
 # * always run tests
-# where a "special" branch is one of main/master or track/**, as
+# where a "special" branch is one of main or track/**, as
 # by convention these branches are the source for a corresponding
 # charmhub edge channel.
 
 on:
   push:
     branches:
-    - master
     - main
     - track/**
 
 jobs:
+
   tests:
     name: Run Tests
     uses: ./.github/workflows/integrate.yaml
-    secrets:
-      charmcraft-credentials: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+    secrets: inherit
 
   # publish runs in series with tests, and only publishes if tests passes
   publish-charm:
     name: Publish Charm
     needs: tests
     uses: ./.github/workflows/publish.yaml
-    secrets:
-      CHARMCRAFT_CREDENTIALS: ${{ secrets.CHARMCRAFT_CREDENTIALS }}
+    secrets: inherit


### PR DESCRIPTION
This PR ensures `main` and `track/1.15` are synced.
Dear reviewer, please note these commits should keep the same hash in both branches.