### PR TITLE
Fix remove integration test

### DIFF
--- a/examples/serve-simple-v1.yaml
+++ b/examples/serve-simple-v1.yaml
@@ -4,6 +4,13 @@ metadata:
   name: seldon-model
 spec:
   name: test-deployment
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "250m"
+    limits:
+      memory: "128Mi"
+      cpu: "250m"
   predictors:
   - componentSpecs:
     - spec:

--- a/examples/sklearn-v2.yaml
+++ b/examples/sklearn-v2.yaml
@@ -5,6 +5,13 @@ metadata:
   name: sklearn
 spec:
   name: iris-predict
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "250m"
+    limits:
+      memory: "128Mi"
+      cpu: "250m"
   protocol: v2 # Activate the V2 protocol
   predictors:
   - graph:

--- a/examples/sklearn.yaml
+++ b/examples/sklearn.yaml
@@ -5,6 +5,13 @@ metadata:
   name: sklearn
 spec:
   name: iris
+  resources:
+    requests:
+      memory: "64Mi"
+      cpu: "250m"
+    limits:
+      memory: "128Mi"
+      cpu: "250m"
   predictors:
   - graph:
       children: []


### PR DESCRIPTION
**NOTE:** *This PR description only contains information related to code changes and testing, if required. All detailed information about problem statement, design, implementation, technical discussions, etc. is tracked in corresponding Github issue indicated below. This will ensure that important information is reliably recorded and tracked and not scattered across PR(s).*

**Details**
Refer to the following Github issue for more information on feature/fix that this PR is related to:
https://github.com/canonical/seldon-core-operator/issues/145

Summary of changes:
- Modified test to remove SeldonDeployments without grace period.
- Switched to using subprocess for application removal.
- Refactored code to simplify SeldonDeployment creating in test.
- Added stop event handler to charm and stopped container in case of stop event.

NOTE: There is a race condition when it comes to removal of the application. Regular ops_test utilities might leave application in 'terminated' state.