### PR TITLE
feat: integrated sklearn server

### DIFF
--- a/src/templates/configmap.yaml.j2
+++ b/src/templates/configmap.yaml.j2
@@ -32,8 +32,8 @@ data:
         "SKLEARN_SERVER": {
           "protocols" : {
             "seldon": {
-              "image": "seldonio/sklearnserver",
-              "defaultImageVersion": "1.15.0"
+              "image": "docker.io/charmedkubeflow/sklearnserver_v1.16.0_20.04_1_amd64",
+              "defaultImageVersion": "v1.16.0_20.04_1"
               },
             "v2": {
               "image": "seldonio/mlserver",


### PR DESCRIPTION
Summary of changes:
- Updated configmap template to refer to sklearnserver ROCK in charmedkubeflow registry instead of upstream.

This complete Sklearn server integration task.