### PR TITLE
feat: mlserver-sklearn integration

### DIFF
--- a/src/templates/configmap.yaml.j2
+++ b/src/templates/configmap.yaml.j2
@@ -36,8 +36,8 @@ data:
               "defaultImageVersion": "v1.16.0_20.04_1"
               },
             "v2": {
-              "image": "seldonio/mlserver",
-              "defaultImageVersion": "1.2.0-sklearn"
+              "image": "docker.io/charmedkubeflow/mlserver-sklearn_1.2.0_22.04_1_amd64",
+              "defaultImageVersion": "1.2.0_22.04_1"
               }
             }
         },

--- a/tests/assets/crs/mlflowserver.yaml
+++ b/tests/assets/crs/mlflowserver.yaml
@@ -7,12 +7,12 @@ spec:
   name: wines
   resources:
     requests:
-      memory: "500Mi"
-      cpu: "500m"
+      memory: "64Mi"
+      cpu: "250m"
       ephemeral-storage: "2G"
     limits:
-      memory: "1G"
-      cpu: "500m"
+      memory: "128Mi"
+      cpu: "250m"
       ephemeral-storage: "2G"
   predictors:
     - graph:

--- a/tests/integration/test_seldon_servers.py
+++ b/tests/integration/test_seldon_servers.py
@@ -97,13 +97,13 @@ async def test_build_and_deploy(ops_test: OpsTest):
                 "model_name": "classifier",
                 "model_version": "v1",
                 "id": None,  # id needs to be reset in response
-                "parameters": {"content_type": None, "headers": None},
+                "parameters": {},
                 "outputs": [
                     {
                         "name": "predict",
                         "shape": [1, 1],
                         "datatype": "INT64",
-                        "parameters": None,
+                        "parameters": {"content_type": "np" },
                         "data": [2],
                     }
                 ],

--- a/tests/integration/test_seldon_servers.py
+++ b/tests/integration/test_seldon_servers.py
@@ -103,7 +103,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
                         "name": "predict",
                         "shape": [1, 1],
                         "datatype": "INT64",
-                        "parameters": {"content_type": "np" },
+                        "parameters": {"content_type": "np"},
                         "data": [2],
                     }
                 ],


### PR DESCRIPTION
Details are in https://github.com/canonical/seldon-core-operator/issues/133

mlsrerver-sklearn rock required some adjustments in integration tests: changes to request and respose test data.

Summary of changes:
- Updated config map with reference to published rock.
- Updated integration tests.