### PR TITLE
feat: script to get all images refernce by charm

### DIFF
--- a/get-images.sh
+++ b/get-images.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+STATIC_IMAGE_LIST=(
+docker.io/seldonio/engine:1.12.0
+docker.io/charmedkubeflow/sklearnserver_v1.16.0_20.04_1_amd64:v1.16.0_20.04_1
+seldonio/mlserver:1.2.0-sklearn
+seldonio/xgboostserver:1.15.0
+seldonio/mlflowserver:1.15.0
+docker.io/charmedkubeflow/mlserver-mlflow_1.2.0_22.04_1:1.2.0_22.04_1
+nvcr.io/nvidia/tritonserver:21.08-py3
+seldonio/mlserver:1.2.0-huggingface
+seldonio/mlserver:1.2.0-slim
+)
+IMAGE_LIST=()
+IMAGE_LIST+=$(yq '.options | ."executor-container-image-and-version" | .default' config.yaml)
+
+printf "%s\n" "${STATIC_IMAGE_LIST[@]}"
+printf "%s\n" "${IMAGE_LIST[@]}"

--- a/get-images.sh
+++ b/get-images.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+#
+# This script returns list of container images that are managed by this charm and/or its workload
+#
+# static list
 STATIC_IMAGE_LIST=(
 docker.io/seldonio/engine:1.12.0
 docker.io/charmedkubeflow/sklearnserver_v1.16.0_20.04_1_amd64:v1.16.0_20.04_1
@@ -10,6 +14,7 @@ nvcr.io/nvidia/tritonserver:21.08-py3
 seldonio/mlserver:1.2.0-huggingface
 seldonio/mlserver:1.2.0-slim
 )
+# dynamic list
 IMAGE_LIST=()
 IMAGE_LIST+=$(yq '.options | ."executor-container-image-and-version" | .default' config.yaml)
 


### PR DESCRIPTION
Each repository needs a way to produce a list of all container image that are managed by charm and by workload. In some cases it can be done by parsing resource and in some cases a static list is created, because programmatic extraction is not warranted.

Summary of changes:
- Script the produce list of images. The list is static. Only one container image is extracted from config.yaml.

NOTE: When container images are replaced with ROCKs this script might become obsolete.