### PR TITLE
feat: integration of mlserver-xgboost rock

### DIFF
--- a/src/templates/configmap.yaml.j2
+++ b/src/templates/configmap.yaml.j2
@@ -32,8 +32,8 @@ data:
         "SKLEARN_SERVER": {
           "protocols" : {
             "seldon": {
-              "image": "seldonio/sklearnserver",
-              "defaultImageVersion": "1.15.0"
+              "image": "docker.io/charmedkubeflow/sklearnserver_v1.16.0_20.04_1_amd64",
+              "defaultImageVersion": "v1.16.0_20.04_1"
               },
             "v2": {
               "image": "seldonio/mlserver",

--- a/src/templates/configmap.yaml.j2
+++ b/src/templates/configmap.yaml.j2
@@ -48,8 +48,8 @@ data:
               "defaultImageVersion": "1.15.0"
               },
             "v2": {
-              "image": "seldonio/mlserver",
-              "defaultImageVersion": "1.2.0-xgboost"
+              "image": "docker.io/charmedkubeflow/mlserver-xgboost_1.2.0_22.04_1_amd64",
+              "defaultImageVersion": "1.2.0_22.04_1"
               }
             }
         },

--- a/tests/integration/test_seldon_servers.py
+++ b/tests/integration/test_seldon_servers.py
@@ -97,7 +97,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
                 "model_name": "classifier",
                 "model_version": "v1",
                 "id": None,  # id needs to be reset in response
-                "parameters": {"content_type": None, "headers": None},
+                "parameters": {},
                 "outputs": [
                     {
                         "name": "predict",

--- a/tests/integration/test_seldon_servers.py
+++ b/tests/integration/test_seldon_servers.py
@@ -147,7 +147,7 @@ async def test_build_and_deploy(ops_test: OpsTest):
                         "name": "predict",
                         "shape": [1, 1],
                         "datatype": "FP32",
-                        "parameters":  {"content_type": "np"},
+                        "parameters": {"content_type": "np"},
                         "data": [2.0],
                     }
                 ],

--- a/tests/integration/test_seldon_servers.py
+++ b/tests/integration/test_seldon_servers.py
@@ -141,13 +141,13 @@ async def test_build_and_deploy(ops_test: OpsTest):
                 "model_name": "iris",
                 "model_version": "v0.1.0",
                 "id": "None",  # id needs to be reset in response
-                "parameters": {"content_type": None, "headers": None},
+                "parameters": {},
                 "outputs": [
                     {
                         "name": "predict",
                         "shape": [1, 1],
                         "datatype": "FP32",
-                        "parameters": None,
+                        "parameters":  {"content_type": "np"},
                         "data": [2.0],
                     }
                 ],


### PR DESCRIPTION
Details are in https://github.com/canonical/seldon-core-operator/issues/133

Summary of changes:
- Added reference to published mlserver-xgboost rock to configmap.
- Update integration test response data.