### PR TITLE
feat: 1.7/stable list of images for this repo

### DIFF
--- a/tools/get-images-1.7-stable.sh
+++ b/tools/get-images-1.7-stable.sh
@@ -4,15 +4,24 @@
 #
 # static list
 STATIC_IMAGE_LIST=(
-docker.io/seldonio/engine:1.12.0
+# from configmap
+tensorflow/serving:2.1.0
+seldonio/tfserving-proxy:1.15.0
 docker.io/charmedkubeflow/sklearnserver_v1.16.0_20.04_1_amd64:v1.16.0_20.04_1
-seldonio/mlserver:1.2.0-sklearn
+docker.io/charmedkubeflow/mlserver-sklearn_1.2.0_22.04_1_amd64:1.2.0_22.04_1
 seldonio/xgboostserver:1.15.0
+docker.io/charmedkubeflow/mlserver-xgboost_1.2.0_22.04_1_amd64:1.2.0_22.04_1
 seldonio/mlflowserver:1.15.0
 docker.io/charmedkubeflow/mlserver-mlflow_1.2.0_22.04_1:1.2.0_22.04_1
 nvcr.io/nvidia/tritonserver:21.08-py3
-seldonio/mlserver:1.2.0-huggingface
+docker.io/charmedkubeflow/mlserver-huggingface_1.2.4_22.04_1_amd64:1.2.4_22.04_1
 seldonio/mlserver:1.2.0-slim
+seldonio/rclone-storage-initializer:1.14.1
+seldonio/alibiexplainer:1.15.0
+seldonio/mlserver:1.2.0-alibi-explain
+# from seldon-core
+docker.io/seldonio/engine:1.12.0
+seldonio/seldon-core-executor:1.13.1
 )
 # dynamic list
 IMAGE_LIST=()


### PR DESCRIPTION
Repository specific list of images. Mostly static in this case.
Used by CVE scanning workflows and can be used to collect images URL for airgapped setup.

Summary of changes:
- Script that produces list of all workload managed container images that are related to this charm's workload.