### PR TITLE
ci: increase storage in GH runners and run integration tests in different machines

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -46,7 +46,11 @@ jobs:
   integration:
     name: Integration Test (build and deploy)
     runs-on: ubuntu-20.04
-
+    strategy:
+      matrix:
+        tox-environments:
+          - charm-integration
+          - seldon-servers-integration
     steps:
     - name: Check out repo
       uses: actions/checkout@v2
@@ -60,7 +64,7 @@ jobs:
         microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
 
     - name: Run integration tests
-      run: tox -ve integration -- --model testing
+      run: tox -ve {{ matrix.tox-environments }} -- --model testing
 
     # On failure, capture debugging resources
     - name: Get all

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -52,6 +52,20 @@ jobs:
           - charm-integration
           - seldon-servers-integration
     steps:
+    # Ideally we'd use self-hosted runners, but this effort is still not stable.
+    # This action will remove unused software (dotnet, haskell, android libs, codeql,
+    # and docker images) from the GH runner, which will liberate around 60 GB of storage
+    # distributed in 40GB for root and around 20 for a mnt point.
+    - name: Maximise GH runner space
+      uses: easimon/maximize-build-space@v7
+      with:
+        root-reserve-mb: 40960
+        remove-dotnet: 'true'
+        remove-haskell: 'true'
+        remove-android: 'true'
+        remove-codeql: 'true'
+        remove-docker-images: 'true'
+
     - name: Check out repo
       uses: actions/checkout@v2
 

--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -78,7 +78,7 @@ jobs:
         microk8s-addons: "dns storage rbac metallb:10.64.140.43-10.64.140.49"
 
     - name: Run integration tests
-      run: tox -ve {{ matrix.tox-environments }} -- --model testing
+      run: tox -ve ${{ matrix.tox-environments }} -- --model testing
 
     # On failure, capture debugging resources
     - name: Get all

--- a/tox.ini
+++ b/tox.ini
@@ -73,10 +73,16 @@ deps =
     -r requirements-unit.txt
 description = Run unit tests
 
-[testenv:integration]
+[testenv:seldon-servers-integration]
 commands =
-    pytest -vv --tb native --asyncio-mode=auto {[vars]tst_path}integration --log-cli-level=INFO -s {posargs}
+    pytest -vv --tb native --asyncio-mode=auto {[vars]tst_path}integration/test_seldon_servers.py --log-cli-level=INFO -s {posargs}
 deps =
     -r requirements-integration.txt
 description = Run integration tests
 
+[testenv:charm-integration]
+commands =
+    pytest -vv --tb native --asyncio-mode=auto {[vars]tst_path}integration/test_charm.py --log-cli-level=INFO -s {posargs}
+deps =
+    -r requirements-integration.txt
+description = Run integration tests


### PR DESCRIPTION
This PR includes the following changes:

* ci: increase storage of GH runners for integration testing
    
Increasing the storage of the GH runners will avoid potential issues when running integration
    tests that deploy SeldonDeployments that require a significant amount of them.
    
Part of #185

* ci: run integration tests in different machines to avoid deploying seldon twice
    
Building and deploying seldon twice in a row may lead to errors while executing test cases from two different
    test files. This change ensures each individual test file runs on its own environment.
    
Part of #185

#### Expected CI failures

* Integration tests may fail during the charm build stage because we are missing changes introduced by #184. To make sure that other CI runs without failures, this PR should be merged first.