### PR TITLE
tests: remove SeldonDeployments even if the test case fails

### DIFF
--- a/tests/integration/test_seldon_servers.py
+++ b/tests/integration/test_seldon_servers.py
@@ -33,7 +33,30 @@ SELDON_DEPLOYMENT = create_namespaced_resource(
     plural="seldondeployments",
     verbs=None,
 )
+ML_MODEL = ""
 
+@pytest.fixture(scope="session")
+def lightkube_client() -> Client:
+    """Return an instantiated lightkube client to use during the session."""
+    lightkube_client = Client(field_manager="kserve")
+    return lightkube_client
+
+@pytest.fixture(scope="module")
+def patch_namespace_with_seldon_label(lightkube_client: Client, ops_test: OpsTest):
+    """Patch the current namespace with Seldon specific labels."""
+    this_ns = lightkube_client.get(res=Namespace, name=ops_test.model_name)
+    this_ns.metadata.labels.update({"serving.kubeflow.org/inferenceservice": "enabled"})
+    lightkube_client.patch(res=Namespace, name=this_ns.metadata.name, obj=this_ns)
+
+@pytest.fixture()
+def remove_seldon_deployment(lightkube_client: Client, ops_test: OpsTest):
+    """Remove SeldonDeployment even if the test case fails."""
+    yield
+
+    # remove Seldon Deployment
+    namespace = ops_test.model_name
+    lightkube_client.delete(SELDON_DEPLOYMENT, name=ML_MODEL, namespace=namespace, grace_period=0)
+    utils.assert_deleted(logger, lightkube_client, SELDON_DEPLOYMENT, ML_MODEL, namespace=namespace)
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
@@ -223,31 +246,29 @@ async def test_build_and_deploy(ops_test: OpsTest):
 )
 @pytest.mark.asyncio
 async def test_seldon_predictor_server(
-    ops_test: OpsTest, server_name, server_config, url, request_data, response_test_data
+    server_name, server_config, url, request_data, response_test_data, lightkube_client, remove_seldon_deployment, ops_test: OpsTest, patch_namespace_with_seldon_label,
 ):
     """Test Seldon predictor server.
 
     Workload deploys Seldon predictor servers defined in ConfigMap.
     Each server is deployed and inference request is triggered, and response is evaluated.
     """
-    # NOTE: This test is re-using deployment created in test_build_and_deploy()
+
     namespace = ops_test.model_name
-    client = Client()
-
-    this_ns = client.get(res=Namespace, name=namespace)
-    this_ns.metadata.labels.update({"serving.kubeflow.org/inferenceservice": "enabled"})
-    client.patch(res=Namespace, name=this_ns.metadata.name, obj=this_ns)
-
     # retrieve predictor server information and create Seldon Depoloyment
     with open(f"tests/assets/crs/{server_config}") as f:
         deploy_yaml = yaml.safe_load(f.read())
-        ml_model = deploy_yaml["metadata"]["name"]
+        # NOTE: Change the value of the global var ML_MODEL according to the Seldon Deployment
+        # that is applied. Changing the global variable will make it easier to remove this
+        # resource in the remove_seldon_deployment fixture without doing more complex fixture magic.
+        global ML_MODEL
+        ML_MODEL = deploy_yaml["metadata"]["name"]
         predictor = deploy_yaml["spec"]["predictors"][0]["name"]
         protocol = "seldon"  # default protocol
         if "protocol" in deploy_yaml["spec"]:
             protocol = deploy_yaml["spec"]["protocol"]
         sdep = SELDON_DEPLOYMENT(deploy_yaml)
-        client.create(sdep, namespace=namespace)
+        lightkube_client.create(sdep, namespace=namespace)
 
     # prepare request data:
     # - if it is string, load it from file specified by that string
@@ -266,11 +287,11 @@ async def test_seldon_predictor_server(
             response_test_data = json.load(f)
 
     # wait for SeldonDeployment to become available
-    utils.assert_available(logger, client, SELDON_DEPLOYMENT, ml_model, namespace)
+    utils.assert_available(logger, lightkube_client, SELDON_DEPLOYMENT, ML_MODEL, namespace)
 
     # obtain prediction service endpoint
-    service_name = f"{ml_model}-{predictor}-classifier"
-    service = client.get(Service, name=service_name, namespace=namespace)
+    service_name = f"{ML_MODEL}-{predictor}-classifier"
+    service = lightkube_client.get(Service, name=service_name, namespace=namespace)
     service_ip = service.spec.clusterIP
     service_port = next(p for p in service.spec.ports if p.name == "http").port
 
@@ -291,7 +312,7 @@ async def test_seldon_predictor_server(
     if protocol == "seldon":
         # retrieve predictor server image from configmap to implicitly verify that it matches
         # deployed predictor server image
-        configmap = client.get(
+        configmap = lightkube_client.get(
             ConfigMap,
             name="seldon-config",
             namespace=ops_test.model_name,
@@ -306,10 +327,6 @@ async def test_seldon_predictor_server(
 
     # verify prediction response
     assert sorted(response.items()) == sorted(response_test_data.items())
-
-    # remove Seldon Deployment
-    client.delete(SELDON_DEPLOYMENT, name=ml_model, namespace=namespace, grace_period=0)
-    utils.assert_deleted(logger, client, SELDON_DEPLOYMENT, ml_model, namespace)
 
     # wait for application to settle
     await ops_test.model.wait_for_idle(

--- a/tests/integration/test_seldon_servers.py
+++ b/tests/integration/test_seldon_servers.py
@@ -267,6 +267,8 @@ async def test_seldon_predictor_server(
         sdep = SELDON_DEPLOYMENT(deploy_yaml)
         # Add a label to the SeldonDeployment so it is easy to interact with it
         # by simply listing the resources that match the test label.
+        if sdep.metadata.labels is None:
+            sdep.metadata.labels = {}
         sdep.metadata.labels.update(TEST_LABEL)
         lightkube_client.create(sdep, namespace=namespace)
 

--- a/tests/integration/test_seldon_servers.py
+++ b/tests/integration/test_seldon_servers.py
@@ -35,11 +35,13 @@ SELDON_DEPLOYMENT = create_namespaced_resource(
 )
 TEST_LABEL = {"testing-seldon-deployments": "true"}
 
+
 @pytest.fixture(scope="session")
 def lightkube_client() -> Client:
     """Return an instantiated lightkube client to use during the session."""
     lightkube_client = Client(field_manager="kserve")
     return lightkube_client
+
 
 @pytest.fixture(scope="module")
 def patch_namespace_with_seldon_label(lightkube_client: Client, ops_test: OpsTest):
@@ -48,6 +50,7 @@ def patch_namespace_with_seldon_label(lightkube_client: Client, ops_test: OpsTes
     this_ns.metadata.labels.update({"serving.kubeflow.org/inferenceservice": "enabled"})
     lightkube_client.patch(res=Namespace, name=this_ns.metadata.name, obj=this_ns)
 
+
 @pytest.fixture()
 def remove_seldon_deployment(lightkube_client: Client, ops_test: OpsTest):
     """Remove SeldonDeployment even if the test case fails."""
@@ -55,10 +58,17 @@ def remove_seldon_deployment(lightkube_client: Client, ops_test: OpsTest):
 
     # remove Seldon Deployment
     namespace = ops_test.model_name
-    resource_to_delete = lightkube_client.list(SELDON_DEPLOYMENT, namespace=namespace, labels=TEST_LABEL)
+    resource_to_delete = lightkube_client.list(
+        SELDON_DEPLOYMENT, namespace=namespace, labels=TEST_LABEL
+    )
     for obj in resource_to_delete:
-        lightkube_client.delete(SELDON_DEPLOYMENT, name=obj.metadata.name, namespace=namespace, grace_period=0)
-        utils.assert_deleted(logger, lightkube_client, SELDON_DEPLOYMENT, obj.metadata.name, namespace=namespace)
+        lightkube_client.delete(
+            SELDON_DEPLOYMENT, name=obj.metadata.name, namespace=namespace, grace_period=0
+        )
+        utils.assert_deleted(
+            logger, lightkube_client, SELDON_DEPLOYMENT, obj.metadata.name, namespace=namespace
+        )
+
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy(ops_test: OpsTest):
@@ -248,7 +258,15 @@ async def test_build_and_deploy(ops_test: OpsTest):
 )
 @pytest.mark.asyncio
 async def test_seldon_predictor_server(
-    server_name, server_config, url, request_data, response_test_data, lightkube_client, remove_seldon_deployment, ops_test: OpsTest, patch_namespace_with_seldon_label,
+    server_name,
+    server_config,
+    url,
+    request_data,
+    response_test_data,
+    lightkube_client,
+    remove_seldon_deployment,
+    ops_test: OpsTest,
+    patch_namespace_with_seldon_label,
 ):
     """Test Seldon predictor server.
 

--- a/tests/integration/test_seldon_servers.py
+++ b/tests/integration/test_seldon_servers.py
@@ -33,7 +33,7 @@ SELDON_DEPLOYMENT = create_namespaced_resource(
     plural="seldondeployments",
     verbs=None,
 )
-TEST_LABEL = {"testing-seldon-deployments": "foo"}
+TEST_LABEL = {"testing-seldon-deployments": "true"}
 
 @pytest.fixture(scope="session")
 def lightkube_client() -> Client:
@@ -265,11 +265,10 @@ async def test_seldon_predictor_server(
         if "protocol" in deploy_yaml["spec"]:
             protocol = deploy_yaml["spec"]["protocol"]
         sdep = SELDON_DEPLOYMENT(deploy_yaml)
-        lightkube_client.create(sdep, namespace=namespace)
         # Add a label to the SeldonDeployment so it is easy to interact with it
         # by simply listing the resources that match the test label.
-        patch = {'metadata': {'labels': TEST_LABEL}}
-        lightkube_client.patch(SELDON_DEPLOYMENT, name=ml_model, namespace=namespace, obj=patch)
+        sdep.metadata.labels.update(TEST_LABEL)
+        lightkube_client.create(sdep, namespace=namespace)
 
     # prepare request data:
     # - if it is string, load it from file specified by that string

--- a/tests/integration/test_seldon_servers.py
+++ b/tests/integration/test_seldon_servers.py
@@ -17,6 +17,7 @@ import utils
 import yaml
 from lightkube import ApiError, Client, codecs
 from lightkube.generic_resource import create_namespaced_resource
+from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.apiextensions_v1 import CustomResourceDefinition
 from lightkube.resources.apps_v1 import Deployment
 from lightkube.resources.core_v1 import ConfigMap, Namespace, Pod, Service
@@ -282,12 +283,9 @@ async def test_seldon_predictor_server(
         protocol = "seldon"  # default protocol
         if "protocol" in deploy_yaml["spec"]:
             protocol = deploy_yaml["spec"]["protocol"]
-        sdep = SELDON_DEPLOYMENT(deploy_yaml)
         # Add a label to the SeldonDeployment so it is easy to interact with it
         # by simply listing the resources that match the test label.
-        if sdep.metadata.labels is None:
-            sdep.metadata.labels = {}
-        sdep.metadata.labels.update(TEST_LABEL)
+        sdep = SELDON_DEPLOYMENT(deploy_yaml, metadata=ObjectMeta(labels=TEST_LABEL))
         lightkube_client.create(sdep, namespace=namespace)
 
     # prepare request data:

--- a/tests/integration/test_seldon_servers.py
+++ b/tests/integration/test_seldon_servers.py
@@ -40,7 +40,7 @@ TEST_LABEL = {"testing-seldon-deployments": "true"}
 @pytest.fixture(scope="session")
 def lightkube_client() -> Client:
     """Return an instantiated lightkube client to use during the session."""
-    lightkube_client = Client(field_manager="kserve")
+    lightkube_client = Client(field_manager="seldon-tests")
     return lightkube_client
 
 
@@ -285,7 +285,12 @@ async def test_seldon_predictor_server(
             protocol = deploy_yaml["spec"]["protocol"]
         # Add a label to the SeldonDeployment so it is easy to interact with it
         # by simply listing the resources that match the test label.
-        sdep = SELDON_DEPLOYMENT(deploy_yaml, metadata=ObjectMeta(labels=TEST_LABEL))
+        sdep = SELDON_DEPLOYMENT(
+            deploy_yaml,
+            metadata=ObjectMeta(
+                name=deploy_yaml["metadata"]["name"], namespace=namespace, labels=TEST_LABEL
+            ),
+        )
         lightkube_client.create(sdep, namespace=namespace)
 
     # prepare request data:


### PR DESCRIPTION
Using a "remove" fixture we can guarantee that the SeldonDeployment under test is actually removed from the testing environment before proceeding with the test execution. This change prevents potential conflicts when the SeldonDeployment has the same name as a previously deployed one and keeps the testing environment clean before continuing.

This commit also moves some of the environment preparations to pytest fixtures to keep the test cases tidy and the test file reusable.

Part of #189 