### PR TITLE
tests: increase number of retries and increase starting time for tenacity retries

### DIFF
--- a/tests/integration/utils.py
+++ b/tests/integration/utils.py
@@ -8,8 +8,8 @@ from lightkube import ApiError
 
 
 @tenacity.retry(
-    wait=tenacity.wait_exponential(multiplier=2, min=1, max=10),
-    stop=tenacity.stop_after_attempt(80),
+    wait=tenacity.wait_exponential(multiplier=2, min=4, max=10),
+    stop=tenacity.stop_after_attempt(90),
     reraise=True,
 )
 def assert_available(logger, client, resource_class, resource_name, namespace):


### PR DESCRIPTION
Increasing the retries and starting time of tenacity retries will ensure the SeldonDeployments can be active and ready to be tested in environments with resources limitations.

Part of #189 