### PR TITLE
fix: Parse custom images with ":" in their name

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -310,7 +310,7 @@ class SeldonCoreOperator(CharmBase):
                 (
                     custom_images[f"{image_name}__image"],
                     custom_images[f"{image_name}__version"],
-                ) = custom_images[image_name].split(":")
+                ) = custom_images[image_name].rsplit(":", 1)
 
         except yaml.YAMLError as err:
             self.logger.error(


### PR DESCRIPTION
For some of the images, the charm attempts to separate the image name from the tag, splitting the string in two using `:` as a separator. However, this breaks the installation if the image name contains that special character, which could be the case if a local container registry address is provided for instance (e.g. `172.17.0.2:5000/tensorflow/serving:2.1.0`).

Use `rsplit` to ensure that the rightmost part of the string (following the last `:`) is parsed as the tag.

Closes #205 