### PR TITLE
fix: updated version of the image

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -42,7 +42,7 @@ options:
     description: https://docs.seldon.io/projects/seldon-core/en/v1.14.0/reference/helm.html
   executor-container-image-and-version:
     type: string
-    default: 'docker.io/seldonio/seldon-core-executor:1.14.0'
+    default: 'docker.io/seldonio/seldon-core-executor:1.17.1'
     description: https://docs.seldon.io/projects/seldon-core/en/v1.14.0/reference/helm.html
   executor-container-image-pull-policy:
     type: string

--- a/config.yaml
+++ b/config.yaml
@@ -43,7 +43,7 @@ options:
   executor-container-image-and-version:
     type: string
     default: 'docker.io/seldonio/seldon-core-executor:1.17.1'
-    description: https://docs.seldon.io/projects/seldon-core/en/v1.14.0/reference/helm.html
+    description: https://docs.seldon.io/projects/seldon-core/en/latest/reference/images.html
   executor-container-image-pull-policy:
     type: string
     default: 'IfNotPresent'


### PR DESCRIPTION
# Description

Update to executor image is required in charm configuration as part of work for updating versions for 1.8 release.

More details are in: https://github.com/canonical/seldon-core-operator/issues/200

Summary of changes:
- Updated version of seldon-core-executor to 1.17.1 for 1.8 release.