### PR TITLE
tests(integration): Apply seldondeployments in namespace `default`

### DIFF
--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -34,6 +34,7 @@ SELDON_DEPLOYMENT = create_namespaced_resource(
     verbs=None,
 )
 SELDON_CM_NAME = "seldon-config"
+DEFAULT_NAMESPACE = "default"
 
 with open("tests/integration/test_data/expected_seldon_cm.json", "r") as json_file:
     SELDON_CONFIG = json.load(json_file)
@@ -102,6 +103,7 @@ async def test_configmap_changes_with_config(lightkube_client: Client, ops_test:
     )
 
 
+@pytest.mark.abort_on_fail
 async def test_seldon_istio_relation(ops_test: OpsTest):
     """Test Seldon/Istio relation."""
     # NOTE: This test is re-using deployment created in test_build_and_deploy()
@@ -162,11 +164,14 @@ async def check_alert_propagation(url, alert_name):
     assert alert_rule is not None and alert_rule["state"] == "firing"
 
 
+@pytest.mark.abort_on_fail
 @pytest.mark.asyncio
 async def test_seldon_alert_rules(ops_test: OpsTest):
     """Test Seldon alert rules."""
     # NOTE: This test is re-using deployments created in test_build_and_deploy()
-    namespace = ops_test.model_name
+    # Use namespace "default" to create seldon deployments
+    # due to https://github.com/canonical/seldon-core-operator/issues/218
+    namespace = DEFAULT_NAMESPACE
     client = Client()
 
     # setup Prometheus
@@ -277,7 +282,9 @@ async def test_seldon_alert_rules(ops_test: OpsTest):
 async def test_seldon_deployment(ops_test: OpsTest):
     """Test Seldon Deployment scenario."""
     # NOTE: This test is re-using deployment created in test_build_and_deploy()
-    namespace = ops_test.model_name
+    # Use namespace "default" to create seldon deployments
+    # due to https://github.com/canonical/seldon-core-operator/issues/218
+    namespace = DEFAULT_NAMESPACE
     client = Client()
 
     this_ns = client.get(res=Namespace, name=namespace)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -34,7 +34,7 @@ SELDON_DEPLOYMENT = create_namespaced_resource(
     verbs=None,
 )
 SELDON_CM_NAME = "seldon-config"
-DEFAULT_NAMESPACE = "default"
+WORKLOADS_NAMESPACE = "default"
 
 with open("tests/integration/test_data/expected_seldon_cm.json", "r") as json_file:
     SELDON_CONFIG = json.load(json_file)
@@ -171,7 +171,7 @@ async def test_seldon_alert_rules(ops_test: OpsTest):
     # NOTE: This test is re-using deployments created in test_build_and_deploy()
     # Use namespace "default" to create seldon deployments
     # due to https://github.com/canonical/seldon-core-operator/issues/218
-    namespace = DEFAULT_NAMESPACE
+    namespace = WORKLOADS_NAMESPACE
     client = Client()
 
     # setup Prometheus
@@ -284,7 +284,7 @@ async def test_seldon_deployment(ops_test: OpsTest):
     # NOTE: This test is re-using deployment created in test_build_and_deploy()
     # Use namespace "default" to create seldon deployments
     # due to https://github.com/canonical/seldon-core-operator/issues/218
-    namespace = DEFAULT_NAMESPACE
+    namespace = WORKLOADS_NAMESPACE
     client = Client()
 
     this_ns = client.get(res=Namespace, name=namespace)

--- a/tests/integration/test_seldon_servers.py
+++ b/tests/integration/test_seldon_servers.py
@@ -35,7 +35,7 @@ SELDON_DEPLOYMENT = create_namespaced_resource(
     verbs=None,
 )
 TEST_LABEL = {"testing-seldon-deployments": "true"}
-DEFAULT_NAMESPACE = "default"
+WORKLOADS_NAMESPACE = "default"
 
 
 @pytest.fixture(scope="session")
@@ -48,7 +48,7 @@ def lightkube_client() -> Client:
 @pytest.fixture(scope="module")
 def patch_namespace_with_seldon_label(lightkube_client: Client, ops_test: OpsTest):
     """Patch the current namespace with Seldon specific labels."""
-    this_ns = lightkube_client.get(res=Namespace, name=DEFAULT_NAMESPACE)
+    this_ns = lightkube_client.get(res=Namespace, name=WORKLOADS_NAMESPACE)
     this_ns.metadata.labels.update({"serving.kubeflow.org/inferenceservice": "enabled"})
     lightkube_client.patch(res=Namespace, name=this_ns.metadata.name, obj=this_ns)
 
@@ -61,7 +61,7 @@ def remove_seldon_deployment(lightkube_client: Client, ops_test: OpsTest):
     # remove Seldon Deployment
     # Use namespace "default" to create seldon deployments
     # due to https://github.com/canonical/seldon-core-operator/issues/218
-    namespace = DEFAULT_NAMESPACE
+    namespace = WORKLOADS_NAMESPACE
     resource_to_delete = lightkube_client.list(
         SELDON_DEPLOYMENT, namespace=namespace, labels=TEST_LABEL
     )
@@ -279,7 +279,7 @@ async def test_seldon_predictor_server(
     """
     # Use namespace "default" to create seldon deployments
     # due to https://github.com/canonical/seldon-core-operator/issues/218
-    namespace = DEFAULT_NAMESPACE
+    namespace = WORKLOADS_NAMESPACE
     # retrieve predictor server information and create Seldon Depoloyment
     with open(f"tests/assets/crs/{server_config}") as f:
         deploy_yaml = yaml.safe_load(f.read())

--- a/tests/integration/test_seldon_servers.py
+++ b/tests/integration/test_seldon_servers.py
@@ -35,6 +35,7 @@ SELDON_DEPLOYMENT = create_namespaced_resource(
     verbs=None,
 )
 TEST_LABEL = {"testing-seldon-deployments": "true"}
+DEFAULT_NAMESPACE = "default"
 
 
 @pytest.fixture(scope="session")
@@ -47,7 +48,7 @@ def lightkube_client() -> Client:
 @pytest.fixture(scope="module")
 def patch_namespace_with_seldon_label(lightkube_client: Client, ops_test: OpsTest):
     """Patch the current namespace with Seldon specific labels."""
-    this_ns = lightkube_client.get(res=Namespace, name=ops_test.model_name)
+    this_ns = lightkube_client.get(res=Namespace, name=DEFAULT_NAMESPACE)
     this_ns.metadata.labels.update({"serving.kubeflow.org/inferenceservice": "enabled"})
     lightkube_client.patch(res=Namespace, name=this_ns.metadata.name, obj=this_ns)
 
@@ -58,7 +59,9 @@ def remove_seldon_deployment(lightkube_client: Client, ops_test: OpsTest):
     yield
 
     # remove Seldon Deployment
-    namespace = ops_test.model_name
+    # Use namespace "default" to create seldon deployments
+    # due to https://github.com/canonical/seldon-core-operator/issues/218
+    namespace = DEFAULT_NAMESPACE
     resource_to_delete = lightkube_client.list(
         SELDON_DEPLOYMENT, namespace=namespace, labels=TEST_LABEL
     )
@@ -274,7 +277,9 @@ async def test_seldon_predictor_server(
     Workload deploys Seldon predictor servers defined in ConfigMap.
     Each server is deployed and inference request is triggered, and response is evaluated.
     """
-    namespace = ops_test.model_name
+    # Use namespace "default" to create seldon deployments
+    # due to https://github.com/canonical/seldon-core-operator/issues/218
+    namespace = DEFAULT_NAMESPACE
     # retrieve predictor server information and create Seldon Depoloyment
     with open(f"tests/assets/crs/{server_config}") as f:
         deploy_yaml = yaml.safe_load(f.read())


### PR DESCRIPTION
Refactor integration tests due to issue #218. 

This is a workaround for the issue. At the same time, it is not needed to revert those back since up until now, integration tests were applying `seldondeployments` to the namespace created by Juju. In production, this would be `kubeflow` and we would never apply something there.