### PR TITLE
ci: Decrease root-reserve-mb to fit the new runner storage

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -70,7 +70,7 @@ jobs:
     - name: Maximise GH runner space
       uses: easimon/maximize-build-space@v8
       with:
-        root-reserve-mb: 40960
+        root-reserve-mb: 29696
         remove-dotnet: 'true'
         remove-haskell: 'true'
         remove-android: 'true'


### PR DESCRIPTION
ci: Decrease root-reserve-mb to fit the new runner storage
addresses https://github.com/canonical/bundle-kubeflow/issues/813