### PR TITLE
fix: correct metrics path for MetricsEndpointProvider (#236)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,8 +1,4 @@
 options:
-  metrics-port:
-    type: string
-    default: '8080'
-    description: Metrics port
   webhook-port:
     type: string
     default: '4443'

--- a/src/prometheus_alert_rules/unit_unavailable.rule
+++ b/src/prometheus_alert_rules/unit_unavailable.rule
@@ -1,6 +1,6 @@
 alert: SeldonUnitIsUnavailable
 expr: up < 1
-for: 0m
+for: 5m
 labels:
   severity: critical
 annotations:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -197,6 +197,12 @@ async def test_seldon_alert_rules(ops_test: OpsTest):
     discovered_labels = targets_result["data"]["activeTargets"][0]["discoveredLabels"]
     assert discovered_labels["juju_application"] == "seldon-controller-manager"
 
+    # query for the up metric and assert the unit is available
+    up_query_response = await fetch_url(
+        f'http://{prometheus_url}:9090/api/v1/query?query=up{{juju_application="{APP_NAME}"}}'
+    )
+    assert up_query_response["data"]["result"][0]["value"][1] == "1"
+
     # obtain alert rules from Prometheus
     rules_url = f"http://{prometheus_url}:9090/api/v1/rules"
     alert_rules_result = await fetch_url(rules_url)

--- a/tests/unit/test_operator.py
+++ b/tests/unit/test_operator.py
@@ -13,7 +13,7 @@ from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus
 from ops.testing import Harness
 
-from charm import SeldonCoreOperator
+from charm import METRICS_PORT, SeldonCoreOperator
 
 SELDON_CM_NAME = "seldon-config"
 
@@ -181,7 +181,7 @@ class TestCharm:
         assert (
             pebble_plan_info["services"]["seldon-core"]["command"] == "/manager "
             "--enable-leader-election "
-            f"--metrics-addr=:{harness.charm._metrics_port} "
+            f"--metrics-addr=:{METRICS_PORT} "
             f"--webhook-port {harness.charm._webhook_port} "
             f"--log-level={harness.charm._manager_log_level} "
             f"--leader-election-id={harness.charm._manager_leader_election_id} "


### PR DESCRIPTION
* fix: correctly configure one scrape job to avoid firig alerts

The metrics endpoint configuration had two scrape jobs, one for the regular metrics endpoint, and a second one based on a dynamic list of targets. The latter was causing the prometheus scraper to try and scrape metrics from *:80/metrics, which is not a valid endpoint. This was causing the UnitsUnavailable alert to fire constantly because that job was reporting back that the endpoint was not available. This new job was introduced by canonical/seldon-core-operator#94 with no apparent justification. Because the seldon charm has changed since that PR, and the endpoint it is configuring is not valid, this commit will remove the extra job.

This commit also refactors the MetricsEndpointProvider instantiation and removes the metrics-port config option as this value should not change.

Finally, this commit changes the alert rule interval from 0m to 5m, as this interval is more appropriate for production environments.

Part of canonical/bundle-kubeflow#564

* tests: add an assertion for checking unit is available

The test_prometheus_grafana_integration test case was doing queries to prometheus and checking the request returned successfully and that the application name and model was listed correctly. To make this test case more accurately, we can add an assertion that also checks that the unit is available, this way we avoid issues like the one described in canonical/bundle-kubeflow#564.

Part of canonical/bundle-kubeflow#564