### PR TITLE
backport(fix): Grafana dashboard shows data from #246

### DIFF
--- a/src/grafana_dashboards/seldon-core.json.tmpl
+++ b/src/grafana_dashboards/seldon-core.json.tmpl
@@ -29,10 +29,7 @@
   "liveNow": false,
   "panels": [
     {
-      "datasource": {
-        "type": "${prometheusds}",
-        "uid": "P19B9F3F8E2C8F6D0"
-      },
+      "datasource": "${prometheusds}",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -107,10 +104,7 @@
       "pluginVersion": "9.2.1",
       "targets": [
         {
-          "datasource": {
-            "type": "${prometheusds}",
-            "uid": "P19B9F3F8E2C8F6D0"
-          },
+          "datasource": "${prometheusds}",
           "editorMode": "builder",
           "exemplar": false,
           "expr": "controller_runtime_webhook_requests_total{webhook=\"/validate-machinelearning-seldon-io-v1-seldondeployment\", code=\"200\"}",
@@ -121,10 +115,7 @@
           "refId": "A"
         },
         {
-          "datasource": {
-            "type": "${prometheusds}",
-            "uid": "P19B9F3F8E2C8F6D0"
-          },
+          "datasource": "${prometheusds}",
           "editorMode": "builder",
           "expr": "controller_runtime_webhook_requests_total{webhook=\"/mutate-machinelearning-seldon-io-v1-seldondeployment\", code=\"500\"}",
           "hide": false,
@@ -140,7 +131,10 @@
   ],
   "schemaVersion": 37,
   "style": "dark",
-  "tags": [],
+  "tags": [
+    "ckf",
+    "seldon"
+  ],
   "templating": {
     "list": []
   },


### PR DESCRIPTION
Backport the following:
* Fix grafana dashboard by removing `uid` from the `datasource` fields.
* Add tags `ckf` and `seldon` to dashboard.

Part of canonical/bundle-kubeflow#856
Refs canonical/bundle-kubeflow#834