### PR TITLE
build: bump jinja2 3.1.x -> 3.1.4 (#262)

### DIFF
--- a/requirements-unit.txt
+++ b/requirements-unit.txt
@@ -40,7 +40,7 @@ importlib-resources==6.0.1
     # via jsonschema
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.2
+jinja2==3.1.4
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ idna==3.4
     #   requests
 importlib-resources==6.0.1
     # via jsonschema
-jinja2==3.1.2
+jinja2==3.1.4
     # via charmed-kubeflow-chisme
 jsonschema==4.17.3
     # via serialized-data-interface


### PR DESCRIPTION
Use charmcraft from latest/candidate in upload-charm in order to unify
the channel used during integration tests and publishing.
Ref canonical/bundle-kubeflow#993